### PR TITLE
correct inputs/outputs getHeelstrikeSimulation for FullGaitCycle

### DIFF
--- a/OCP/OCP_formulation.m
+++ b/OCP/OCP_formulation.m
@@ -639,7 +639,7 @@ else % S.post_process.load_prev_opti_vars = true
     
     % Advanced feature, for debugging only: load w_opt and reconstruct R before rerunning the post-processing.
     Outname = fullfile(S.subject.save_folder,[S.post_process.result_filename '.mat']);
-    disp(['Loading vector with optimization variables from previous solution: ' outname])
+    disp(['Loading vector with optimization variables from previous solution: ' Outname])
     clear 'S'
     load(Outname,'w_opt','stats','setup','model_info','R','S');
     scaling = setup.scaling;

--- a/OCP/OCP_formulation.m
+++ b/OCP/OCP_formulation.m
@@ -1117,7 +1117,7 @@ if strcmp(S.misc.gaitmotion_type,'HalfGaitCycle')
 
 elseif strcmp(S.misc.gaitmotion_type,'FullGaitCycle')
     % detect heelstrike
-    [IC1i_c,IC1i_s,HS1] = getHeelstrikeSimulation(GRFk_opt,N);
+    [IC1i_c,IC1i_s,HS1,HS_threshold] = getHeelstrikeSimulation(GRFk_opt,N,model_info.mass/3);
         
     % Qs
     Qs_GC = zeros(N,size(q_opt_unsc.deg,2));

--- a/main.m
+++ b/main.m
@@ -72,7 +72,7 @@ S.solver.run_as_batch_job = 0;
 % S.misc.poly_order.lower    = ;
 % S.misc.poly_order.upper    = ;
 % S.misc.msk_geom_bounds      = {{'knee_angle_r','knee_angle_l'},-120,10,'pelvis_tilt',-30,30};
-% S.misc.gaitmotion_type = ;
+% S.misc.gaitmotion_type = 'FullGaitCycle';
 
 % % S.post_process
 S.post_process.make_plot = 1;


### PR DESCRIPTION
getHeelstrikeSimulation was updated to work for wider range of subject mass. New input and output argument were added.

Calling this function for reconstructing full gait cycle still used the old arguments.