### PR TITLE
Bugfix ligaments and cleanup

### DIFF
--- a/CasadiFunctions/createCasadi_Ligaments.m
+++ b/CasadiFunctions/createCasadi_Ligaments.m
@@ -45,11 +45,14 @@ M_lig_single_MX = MX(model_info.ExtFunIO.jointi.nq.all,1);
 % ligaments that cross multiple degrees of freedom
 M_lig_multi_MX = MX(model_info.ExtFunIO.jointi.nq.all,1);
 
+% initialise ligament length, lenghtening velocity, and force
+L_lig_pp_MX = MX(model_info.ligament_info.NLigament,1);
+v_lig_pp_MX = MX(model_info.ligament_info.NLigament,1);
+F_lig_pp_MX = MX(model_info.ligament_info.NLigament,1);
+
 if model_info.ligament_info.NLigament > 0
 
-    L_lig_pp_MX = MX(model_info.ligament_info.NLigament,1);
-    F_lig_pp_MX = MX(model_info.ligament_info.NLigament,1);
-
+    
     %% Ligaments that cross a single coordinate
     % These are grouped as a lumped angle-torque
 

--- a/PlotFigures/run_this_file_to_plot_figures.m
+++ b/PlotFigures/run_this_file_to_plot_figures.m
@@ -19,21 +19,17 @@ clc
 % Construct a cell array with full paths to files with saved results for
 % which you want to appear on the plotted figures.
 results_folder = fullfile(pathRepoFolder,'PredSimResults');
-% result_paths{1} = fullfile(pathRepo,'Tests','Falisse_et_al_2022_Results','Falisse_et_al_2022_v1.mat');
-result_paths{1} = fullfile(results_folder,'DHondt_2023_3seg\DHondt_2023_3seg_ref.mat');
-result_paths{end+1} = fullfile(results_folder,'DHondt_2023_3seg\DHondt_2023_3seg_job667.mat');
-result_paths{end+1} = fullfile(results_folder,'DHondt_2023_3seg\DHondt_2023_3seg_job669.mat');
-
+result_paths{1} = fullfile(pathRepo,'Tests','Falisse_et_al_2022_Results','Falisse_et_al_2022_v1.mat');
+% result_paths{2} = fullfile(results_folder,'Falisse_et_al_2022_Results','Falisse_et_al_2022_v1.mat');
 
 % Cell array with legend name for each result
-legend_names = {'N = 100, quasi-random IG (reference)', 'N = 50, data-informed IG (PredSim)',...
-    'N = 100, quasi-random IG (PredSim)'};
+legend_names = {'Reference result', 'Your first simulation'};
 
 % Path to the folder where figures are saved
-figure_folder = fullfile(results_folder,'DHondt_2023_3seg');
+figure_folder = results_folder;
 
 % Common part of the filename for all saved figures
-figure_savename = '3-segment_foot_model';
+figure_savename = 'MyFirstPredictiveSimulationFigure';
 
 %% Settings for each figure to be made
 % "figure_settings" is a cell array where each cell contains a struct with
@@ -73,7 +69,7 @@ figure_settings(fig_count).name = 'all_angles';
 figure_settings(fig_count).dofs = {'all_coords'};
 figure_settings(fig_count).variables = {'Qs'};
 figure_settings(fig_count).savepath = fullfile(figure_folder,[figure_savename '_' figure_settings(fig_count).name]);
-figure_settings(fig_count).filetype = {'png'};
+figure_settings(fig_count).filetype = {};
 fig_count = fig_count+1;
 
 % figure_settings(fig_count).name = 'all_angles';
@@ -94,7 +90,7 @@ figure_settings(fig_count).name = 'all_activations';
 figure_settings(fig_count).dofs = {'muscles_r'};
 figure_settings(fig_count).variables = {'a'};
 figure_settings(fig_count).savepath = fullfile(figure_folder,[figure_savename '_' figure_settings(fig_count).name]);
-figure_settings(fig_count).filetype = {'png'};
+figure_settings(fig_count).filetype = {};
 fig_count = fig_count+1;
 
 % figure_settings(fig_count).name = 'selected_angles';
@@ -105,19 +101,19 @@ fig_count = fig_count+1;
 % figure_settings(fig_count).filetype = {'jpeg'};
 % fig_count = fig_count+1;
 
-figure_settings(fig_count).name = 'torques';
-figure_settings(fig_count).dofs = {'all_coords'};
-figure_settings(fig_count).variables = {'T_ID'};
-figure_settings(fig_count).savepath = fullfile(figure_folder,[figure_savename '_' figure_settings(fig_count).name]);
-figure_settings(fig_count).filetype = {'png'};
-fig_count = fig_count+1;
+% figure_settings(fig_count).name = 'torques';
+% figure_settings(fig_count).dofs = {'all_coords'};
+% figure_settings(fig_count).variables = {'T_ID'};
+% figure_settings(fig_count).savepath = fullfile(figure_folder,[figure_savename '_' figure_settings(fig_count).name]);
+% figure_settings(fig_count).filetype = {'png'};
+% fig_count = fig_count+1;
 
-figure_settings(fig_count).name = 'ankle_muscles';
-figure_settings(fig_count).dofs = {'soleus_r','med_gas_r','lat_gas_r','tib_ant_r'};
-figure_settings(fig_count).variables = {'a','FT','lMtilde','Wdot','Edot_gait'};
-figure_settings(fig_count).savepath = fullfile(figure_folder,[figure_savename '_' figure_settings(fig_count).name]);
-figure_settings(fig_count).filetype = {};
-fig_count = fig_count+1;
+% figure_settings(fig_count).name = 'ankle_muscles';
+% figure_settings(fig_count).dofs = {'soleus_r','med_gas_r','lat_gas_r','tib_ant_r'};
+% figure_settings(fig_count).variables = {'a','FT','lMtilde','Wdot','Edot_gait'};
+% figure_settings(fig_count).savepath = fullfile(figure_folder,[figure_savename '_' figure_settings(fig_count).name]);
+% figure_settings(fig_count).filetype = {};
+% fig_count = fig_count+1;
 
 % figure_settings(fig_count).name = 'grfs';
 % figure_settings(fig_count).dofs = {'custom'};

--- a/main.m
+++ b/main.m
@@ -16,14 +16,14 @@ clc
 pathDefaultSettings = fullfile(pathRepo,'DefaultSettings');
 addpath(pathDefaultSettings)
 
-[S] = initializeSettings('DHondt_2023_3seg');
+[S] = initializeSettings('Falisse_et_al_2022');
 S.misc.main_path = pathRepo;
 
 addpath(fullfile(S.misc.main_path,'VariousFunctions'))
 
 %% Required inputs
 % name of the subject
-S.subject.name = 'DHondt_2023_3seg';
+S.subject.name = 'Falisse_et_al_2022';
 
 % path to folder where you want to store the results of the OCP
 S.subject.save_folder  = fullfile(pathRepoFolder,'PredSimResults',S.subject.name); 
@@ -31,7 +31,7 @@ S.subject.save_folder  = fullfile(pathRepoFolder,'PredSimResults',S.subject.name
 % either choose "quasi-random" or give the path to a .mot file you want to use as initial guess
 S.subject.IG_selection = fullfile(S.misc.main_path,'OCP','IK_Guess_Full_GC.mot');
 S.subject.IG_selection_gaitCyclePercent = 100;
-S.subject.IG_selection = 'quasi-random';
+% S.subject.IG_selection = 'quasi-random';
 
 % give the path to the osim model of your subject
 osim_path = fullfile(pathRepo,'Subjects',S.subject.name,[S.subject.name '.osim']);
@@ -75,7 +75,7 @@ S.solver.run_as_batch_job = 0;
 % S.misc.gaitmotion_type = 'FullGaitCycle';
 
 % % S.post_process
-S.post_process.make_plot = 0;
+S.post_process.make_plot = 1;
 % S.post_process.savename  = 'datetime';
 % S.post_process.load_prev_opti_vars = 1;
 % S.post_process.rerun   = 1;


### PR DESCRIPTION
Follow-up for PR #91 

## Changes
### Bugfix
Initialise length, velocity, force of ligaments with empty vectors when the model has no ligaments to prevent error when creating functions.

### Consistency
Set main and plot scripts to target Falisse_et_al_2022 model

## Testing done
Run simulations for 5 iterations and compare ipopt printout:
- [x] DHondt_2023_3seg with its default settings
- [x] Falisse_et_al_2022 with its default settings 

