### PR TITLE
Add template for pull requests

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,20 @@
+<!--- Provide a general summary of your changes in the Title above -->
+
+## Description
+<!--- Provide a short overview of the changes -->
+
+## Motivation and Context
+<!--- Why is this change required? What problem does it solve? -->
+<!--- If it fixes an open issue, please link to the issue here. -->
+
+## How Has This Been Tested?
+<!--- Please describe how you tested your changes. -->
+<!--- Please describe the outcome of these tests. -->
+
+## Suggested tests for reviewers
+<!---Please describe tests for the reviewer to run -->
+
+
+<!--- Assign labels ("Labels" tab in side bar). Each PR should have at least one "Review:..." label, since we use these to allocate reviewers. -->
+<!--- Do not add requested reviewers, unless this person specifically agreed to review your PR. -->
+<!--- If you are a collaborator (i.e. have direct write access to this repo) select yourself as assignee, otherwise someone will be assigned to your PR. -->


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Provide a short overview of the changes -->
I added a PR template to the .github folder. The template is based on https://github.com/KULeuvenNeuromechanics/PredSim/wiki/Guidelines-for-contributing-code#Pull-request

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This change helps to standardize pull requests and makes sure contributors do not miss on important information.

## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
<!--- Please describe the outcome of these tests. -->
Testing to see if it works is only possible when this file exists in the default branch. See https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates#pull-request-templates. Though, GitHub should recognize the filename once it is on the default branch.

I copied the contents of the template to this text field. I.e., you here see the template in action, though not automatically yet.

## Suggested tests for reviewers
<!---Please describe tests for the reviewer to run -->
To visualize how the template will look, copy the contents of the file to a comment field and click 'Preview'. Furthermore, check if the content of the file is correct.

<!--- Assign labels ("Labels" tab in side bar). Each PR should have at least one "Review:..." label, since we use these to allocate reviewers. -->
<!--- Do not add requested reviewers, unless this person specifically agreed to review your PR. -->
<!--- If you are a collaborator (i.e. have direct write access to this repo) select yourself as assignee, otherwise someone will be assigned to your PR. -->