### PR TITLE
Add scaling of pcsa_force of ligaments

### DIFF
--- a/AdaptOpenSimModel/AdaptOpenSimModel.m
+++ b/AdaptOpenSimModel/AdaptOpenSimModel.m
@@ -27,6 +27,11 @@
 %   setting to scale contact sphere locations with respect to a reference
 %   model.
 % 
+%   - scale_ligaments_bool -
+%   * OpenSim scale tool does not adapt ligament pcsa. Use this setting to 
+%   scale ligament pcsa_force with respect to a reference model.
+%
+%
 % Original author: Lars D'Hondt
 % Original date: 27/May/2022
 %
@@ -54,6 +59,7 @@ add_contact_bool = 0;
 use_reference_contacts_bool = 1;
 scale_contact_spheres_bool = 1;
 scale_contact_location_bool = 1;
+scale_ligaments_bool = 1;
 
 %% Define contact spheres
 
@@ -188,4 +194,6 @@ end
 if scale_contact_location_bool
     fixContactSpherePositionAfterScaling(path_reference_model,path_osim_out);
 end
-
+if scale_ligaments_bool
+    scaleLigaments(path_osim_out, path_reference_model);
+end

--- a/AdaptOpenSimModel/scaleLigaments.m
+++ b/AdaptOpenSimModel/scaleLigaments.m
@@ -22,7 +22,7 @@ function [] = scaleLigaments(osim_path_scaled, bodymass_generic)
 % Original date: 9 February 2024
 % --------------------------------------------------------------------------
 
-
+% get mass of generic model
 if isnumeric(bodymass_generic) && numel(bodymass_generic)==1
     mass_generic = bodymass_generic;
 else
@@ -30,14 +30,16 @@ else
     mass_generic = getModelMass(osim_path_generic);
 end
 
+% get mass of scaled model
 mass_scaled = getModelMass(osim_path_scaled);
 
-
+% scale factor
 scale_factor = (mass_scaled/mass_generic)^(2/3);
 
 import org.opensim.modeling.*;
 model = Model(osim_path_scaled);
 
+% apply scaling
 for i=1:model.getForceSet().getSize()
     force_i = model.getForceSet().get(i-1);
     if strcmp(force_i.getConcreteClassName(),'Ligament')
@@ -49,8 +51,9 @@ for i=1:model.getForceSet().getSize()
     end
 end
 
+% save model
 model.initSystem();
 model.print(osim_path_scaled);
 
 
-end
+end % end of function

--- a/AdaptOpenSimModel/scaleLigaments.m
+++ b/AdaptOpenSimModel/scaleLigaments.m
@@ -1,0 +1,56 @@
+function [] = scaleLigaments(osim_path_scaled, bodymass_generic)
+% --------------------------------------------------------------------------
+% scaleLigaments
+%   Scales the ligament properties of an OpenSim model that are not scaled
+%   by the scale tool. This only includes properties that are used by
+%   PredSim, i.e. 
+%       pcsa_force: ~mass^(2/3)
+% 
+%
+% INPUT:
+%   - osim_path_scaled -
+%   * OpenSim model where ligaments will be scaled. Ligaments will be read
+%   from this model, scaled, and written back to this model.
+% 
+%   - bodymass_generic -
+%   * body mass of the generic (unsclaed) model. Used to determine the mass
+%   ratio for the scaling factor. Alternatively, pass the path to the
+%   generic OpenSim model.
+%
+% 
+% Original author: Lars D'Hondt
+% Original date: 9 February 2024
+% --------------------------------------------------------------------------
+
+
+if isnumeric(bodymass_generic) && numel(bodymass_generic)==1
+    mass_generic = bodymass_generic;
+else
+    osim_path_generic = bodymass_generic;
+    mass_generic = getModelMass(osim_path_generic);
+end
+
+mass_scaled = getModelMass(osim_path_scaled);
+
+
+scale_factor = (mass_scaled/mass_generic)^(2/3);
+
+import org.opensim.modeling.*;
+model = Model(osim_path_scaled);
+
+for i=1:model.getForceSet().getSize()
+    force_i = model.getForceSet().get(i-1);
+    if strcmp(force_i.getConcreteClassName(),'Ligament')
+        lig = Ligament.safeDownCast(force_i);
+        PCSA_force_old = lig.get_pcsa_force();
+        PCSA_force_new = PCSA_force_old *scale_factor;
+        lig.set_pcsa_force(PCSA_force_new);
+
+    end
+end
+
+model.initSystem();
+model.print(osim_path_scaled);
+
+
+end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Provide a short overview of the changes -->
Add a function that scales the pcsa_force element of ligaments based on the mass of the scaled model.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
OpenSim only scales the resting_length in the scale tool. See also #120. We assume that the psca_force scales similar als FMo based on mass.

## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
<!--- Please describe the outcome of these tests. -->
Ran the function scaleLigaments(path_osim_out, path_reference_model) and checked in the resulting osim model if the pcsa was scaled..

## Suggested tests for reviewers
<!---Please describe tests for the reviewer to run -->
TBD.

<!--- Assign labels ("Labels" tab in side bar). Each PR should have at least one "Review:..." label, since we use these to allocate reviewers. -->
<!--- Do not add requested reviewers, unless this person specifically agreed to review your PR. -->
<!--- If you are a collaborator (i.e. have direct write access to this repo) select yourself as assignee, otherwise someone will be assigned to your PR. -->
