### PR TITLE
Bugfix reference results

### DIFF
--- a/PlotFigures/run_this_file_to_plot_figures.m
+++ b/PlotFigures/run_this_file_to_plot_figures.m
@@ -19,7 +19,7 @@ clc
 % Construct a cell array with full paths to files with saved results for
 % which you want to appear on the plotted figures.
 results_folder = fullfile(pathRepoFolder,'PredSimResults');
-result_paths{1} = fullfile(pathRepo,'Tests','Falisse_et_al_2022_Results','Falisse_et_al_2022_v1.mat');
+result_paths{1} = fullfile(pathRepo,'Tests','ReferenceResults','Falisse_et_al_2022','Falisse_et_al_2022_paper.mat');
 % result_paths{2} = fullfile(results_folder,'Falisse_et_al_2022_Results','Falisse_et_al_2022_v1.mat');
 
 


### PR DESCRIPTION
updated 1 line for correct reference directory

## Motivation and Context
Error when trying to plot results, it appears that reference to folder with reference results (Falisse et al., 2022) isnt correct/hasnt been updated.

## How Has This Been Tested?
load .mat file with results as S and run main.m line 20-151 


