### PR TITLE
Save info about polynomial fit of musculoskeletal geometry

### DIFF
--- a/PreProcessing/get_musculoskeletal_geometry_approximation.m
+++ b/PreProcessing/get_musculoskeletal_geometry_approximation.m
@@ -41,6 +41,7 @@ if strcmp(S.misc.msk_geom_eq,'polynomials')
     if ~isfile(fullfile(S.misc.subject_path,S.misc.msk_geom_name)) || ~isempty(S.misc.msk_geom_bounds)
         % Analyze the muscle-tendon lengths, velocities, and moment arms in function of coordinate values
         t0 = tic;
+        disp(['   start analysing musculoskeletal geometry...'])
         muscle_data = muscleAnalysisAPI(S,osim_path,model_info);
         disp(['   analysing MSK geometry: ' num2str(toc(t0),'%.2f') ' s'])
 
@@ -49,8 +50,14 @@ if strcmp(S.misc.msk_geom_eq,'polynomials')
         model_info.muscle_info.polyFit.MuscleInfo = PolynomialFit(S,muscle_data,model_info.muscle_info.muscle_spanning_joint_info);
         disp(['   approximating MSK geometry: ' num2str(toc(t1),'%.2f') ' s'])
 %         disp(['   (total duration: ' num2str(toc(t0)) ' s)'])
+        
+        % Save sampling and fitting data
+        msk_geom_fit_info.samples = muscle_data;
+        msk_geom_fit_info.fit = model_info.muscle_info.polyFit.MuscleInfo;
+        save(fullfile(S.misc.subject_path,[S.misc.msk_geom_name,'_info.mat']), 'msk_geom_fit_info')
+        
     else
-        disp(['   using existing MSK geometry ' S.misc.msk_geom_name])
+        disp(['   using existing musculoskeletal geometry ' S.misc.msk_geom_name])
     end
 
 else


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Provide a short overview of the changes -->
Information about the polynomial fit of musculoskeletal geometry (samples, coefficients, order, RMSE) is now saved to a file. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This info can be useful for identifying simulation problems or to inform model improvements, but was difficult to access.

## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
<!--- Please describe the outcome of these tests. -->
Changed code does not influence the actual simulation.

## Suggested tests for reviewers
<!---Please describe tests for the reviewer to run -->
1. delete polynomial file (`<modelname>_f_lMT_vMT_dM_poly_*_*`) for a model from subject folder
2. run a simulation with this model (5 iterations is enough)
3. observe that you have a file `<modelname>_f_lMT_vMT_dM_poly_*_*_info.mat` in the subject folder


<!--- Assign labels ("Labels" tab in side bar). Each PR should have at least one "Review:..." label, since we use these to allocate reviewers. -->
<!--- Do not add requested reviewers, unless this person specifically agreed to review your PR. -->
<!--- If you are a collaborator (i.e. have direct write access to this repo) select yourself as assignee, otherwise someone will be assigned to your PR. -->
