### PR TITLE
Update getStancePhaseSimulation.m

### DIFF
--- a/OCP/getStancePhaseSimulation.m
+++ b/OCP/getStancePhaseSimulation.m
@@ -43,9 +43,11 @@ threshold = threshold_init;
 nFramesBelow= sum(GRFy < threshold,"all");
 while nFramesBelow == 0
     threshold = threshold + 1;
-    nFramesBelow= sum(GRFy < threshold,"all");
+    nFramesBelow = sum(GRFy < threshold,"all");
     if threshold-threshold_init > 200
-        error('Vertical ground reaction forces are all way above heelstrike threshold.') % just in case
+        warning(['Vertical ground reaction forces are all way above heelstrike threshold. ' ...
+            'First mesh point of post-processed results may not reflect initial contact.'])
+        break
     end
 end
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Provide a short overview of the changes -->
When detecting initial contact for the simulated gait, there was an error in case all GRFs exceed the initial threshold by more than 200N. 
I changed the error to a warning, and made the workflow continue with threshold trial value.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When running a simulation for only a few iterations (e.g. 5 iterations for the automated testing routine), the result does not have to be physically consistent and can have very high GRF. This would then trigger the error, breaking the testing routine (even when the test should have been successful).

## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
<!--- Please describe the outcome of these tests. -->
run test_PredSim

## Suggested tests for reviewers
<!---Please describe tests for the reviewer to run -->
run test_PredSim

<!--- Assign labels ("Labels" tab in side bar). Each PR should have at least one "Review:..." label, since we use these to allocate reviewers. -->
<!--- Do not add requested reviewers, unless this person specifically agreed to review your PR. -->
<!--- If you are a collaborator (i.e. have direct write access to this repo) select yourself as assignee, otherwise someone will be assigned to your PR. -->
