### PR TITLE
Setting batch job paths

### DIFF
--- a/DefaultSettings/getDefaultSettings.m
+++ b/DefaultSettings/getDefaultSettings.m
@@ -341,16 +341,6 @@ if ~isfield(S.solver,'N_meshes')
     end
 end
 
-% parallel cluster
-if ~isfield(S.solver,'par_cluster_name')
-    S.solver.par_cluster_name = [];
-end
-
-% batch job additional paths
-if ~isfield(S.solver,'batch_job_paths')
-    S.solver.batch_job_paths = {};
-end
-
 % initial guess inputs
 % input should be a string: "quasi-random" or the path to a .mot file
 if ~isfield(S.solver,'IG_selection')

--- a/DefaultSettings/getDefaultSettings.m
+++ b/DefaultSettings/getDefaultSettings.m
@@ -341,7 +341,15 @@ if ~isfield(S.solver,'N_meshes')
     end
 end
 
+% parallel cluster
+if ~isfield(S.solver,'par_cluster_name')
+    S.solver.par_cluster_name = [];
+end
 
+% batch job additional paths
+if ~isfield(S.solver,'batch_job_paths')
+    S.solver.batch_job_paths = {};
+end
 
 % initial guess inputs
 % input should be a string: "quasi-random" or the path to a .mot file

--- a/DefaultSettings/initializeSettings.m
+++ b/DefaultSettings/initializeSettings.m
@@ -57,6 +57,12 @@ S.misc.main_path = pathRepo;
 % do not run as batch job (parallel computing toolbox)
 S.solver.run_as_batch_job = false;
 
+% parallel cluster
+S.solver.par_cluster_name = [];
+
+% batch job additional paths
+S.solver.batch_job_paths = {};
+
 %%
 if ~isempty(varargin)
 

--- a/Documentation/SettingsOverview.md
+++ b/Documentation/SettingsOverview.md
@@ -169,6 +169,10 @@ Quickly navigate to:
     - number of mesh intervals. Default is *50* [double] for S.misc.gaitmotion_type = HalfGaitCycle and *100* for FullGaitCycle	
 - **S.solver.run_as_batch_job**: 
     - specify if the OCP is to be solved as a batch job. Default is *false* [bool]. Batch processing requires the [Parallel Computing Toolbox](https://nl.mathworks.com/products/parallel-computing.html).
+- **S.solver.batch_job_paths**:
+    - if your simulation requires functions that are not inside the PredSim repo and you want to run this simulation as a batch job, then you have to include the path to the folder with these functions. Default is *{}* [cell array of char].
+- **S.solver.par_cluster_name**:
+    - name of the parallel cluster used to run batch jobs. Run `parallel.clusterProfiles` to see your available clusters. Default is *[]* [char] and will use your default cluster.
 - **S.solver.parallel_mode**: 
     - type of parallel computing. Default is *thread* [char]. Other types are not supported.
 - **S.solver.N_threads**: 

--- a/add_pred_sim_to_batch.m
+++ b/add_pred_sim_to_batch.m
@@ -34,7 +34,7 @@ else
 end
 % Running a function as part of batch needs all paths that are called inside
 % the function
-additional_paths = {};
+additional_paths = S.solver.batch_job_paths;
 [pathOsim,~,~] = fileparts(osim_path);
 additional_paths{end+1} = pathOsim;
 additional_paths{end+1} = fullfile(S.misc.main_path,'DefaultSettings');


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Provide a short overview of the changes -->
- Added a setting to pass paths to the batch job, in case it needs a function that is not inside the PredSim repository.
- Included settings to select cluster for batch job to the documentation, since it was missing.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Simulations with e.g. orthosis function in a different folder will cause an error when running in batch.

## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
<!--- Please describe the outcome of these tests. -->
Simulations with orthosis function from the workshop repo (e.g. example_2) can run in batch.

## Suggested tests for reviewers
<!---Please describe tests for the reviewer to run -->
Run workshop example_2 (hands-on modelling assistive devices)

<!--- Assign labels ("Labels" tab in side bar). Each PR should have at least one "Review:..." label, since we use these to allocate reviewers. -->
<!--- Do not add requested reviewers, unless this person specifically agreed to review your PR. -->
<!--- If you are a collaborator (i.e. have direct write access to this repo) select yourself as assignee, otherwise someone will be assigned to your PR. -->
