### PR TITLE
bugfix-get_git_hash

### DIFF
--- a/DefaultSettings/get_git_hash.m
+++ b/DefaultSettings/get_git_hash.m
@@ -1,4 +1,4 @@
-function [local_hash, branch_name, remote_hash] = get_git_hash
+function [local_hash, branch_name, remote_hash] = get_git_hash(pathRepo)
 % --------------------------------------------------------------------------
 %get_git_hash 
 %   Gets the hash of the current github code used. The git hash is used to
@@ -6,7 +6,9 @@ function [local_hash, branch_name, remote_hash] = get_git_hash
 %   version's code on GitHub by pasting the hash at 'commit-hash':
 %   https://github.com/KULeuvenNeuromechanics/PredSim/tree/commit-hash
 % 
-% INPUT: none
+% INPUT:
+%   -pathRepo-
+%   * path to the repository
 % 
 % OUTPUT:
 %   -local_hash-
@@ -24,6 +26,11 @@ function [local_hash, branch_name, remote_hash] = get_git_hash
 % Last edit by: Bram Van Den Bosch
 % Last edit date: 26/05/2023
 % --------------------------------------------------------------------------
+
+% save current working directory
+pathInitDir = pwd;
+% move to PredSim
+cd(pathRepo)
 
 % get hash of the local instance
 command = ['git rev-parse HEAD'];
@@ -49,5 +56,8 @@ if status == 0
         warning(['There is a more recent version of this branch on the remote: https://github.com/KULeuvenNeuromechanics/PredSim/tree/' remote_hash]);
     end
 end
+
+% return to initial directory
+cd(pathInitDir)
 
 end

--- a/DefaultSettings/initializeSettings.m
+++ b/DefaultSettings/initializeSettings.m
@@ -16,6 +16,10 @@ function [S] = initializeSettings(varargin)
 % Original date: 01/12/2021
 % --------------------------------------------------------------------------
 
+% get path to repo
+[pathHere,~,~] = fileparts(mfilename('fullpath'));
+[pathRepo,~,~] = fileparts(pathHere);
+
 S = struct;
 
 S.metabolicE   = [];
@@ -41,7 +45,7 @@ S.misc.poly_order = [];
 S.orthosis.settings = {};
 
 % save the git hash
-[S.misc.git.local_hash,S.misc.git.branch_name, S.misc.git.remote_hash] = get_git_hash;
+[S.misc.git.local_hash,S.misc.git.branch_name, S.misc.git.remote_hash] = get_git_hash(pathRepo);
 
 % initiate for warning
 S.subject.adapt_IG_pelvis_y = 0;
@@ -50,8 +54,6 @@ S.subject.adapt_IG_pelvis_y = 0;
 S.misc.computername = getenv('COMPUTERNAME');
 
 % save path to repo
-[pathHere,~,~] = fileparts(mfilename('fullpath'));
-[pathRepo,~,~] = fileparts(pathHere);
 S.misc.main_path = pathRepo;
 
 % do not run as batch job (parallel computing toolbox)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Provide a short overview of the changes -->
Move to PredSim repo before getting git hash, and move back to initial folder after.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When calling initializeSettings from a script not in the PredSim repo, it would get the git hash of that other repo.

## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
<!--- Please describe the outcome of these tests. -->
Running initializeSettings while the working directory is not the PredSim repo, the git hash and branch name still match PredSim.

## Suggested tests for reviewers
<!---Please describe tests for the reviewer to run -->
Run initializeSettings while the working directory is not the PredSim repo.

<!--- Assign labels ("Labels" tab in side bar). Each PR should have at least one "Review:..." label, since we use these to allocate reviewers. -->
<!--- Do not add requested reviewers, unless this person specifically agreed to review your PR. -->
<!--- If you are a collaborator (i.e. have direct write access to this repo) select yourself as assignee, otherwise someone will be assigned to your PR. -->
