### PR TITLE
bugfix: models with different muscles for left and right side no longer cause an error

### DIFF
--- a/PreProcessing/get_model_info.m
+++ b/PreProcessing/get_model_info.m
@@ -93,11 +93,19 @@ model_info = getCoordinateIndexForStateVectorOpenSimAPI(S,osim_path,model_info);
 [symQs, model_info.ExtFunIO.jointi] = identify_kinematic_chains(S,osim_path,model_info);
 
 orderMus = 1:length(model_info.muscle_info.muscle_names);
-orderMusInv = zeros(1,length(model_info.muscle_info.muscle_names));
+orderMusInv = orderMus;
 for i=1:length(model_info.muscle_info.muscle_names)
 
-    orderMusInv(i) = find(strcmp(model_info.muscle_info.muscle_names,...
+    idx_mus_inv_i = find(strcmp(model_info.muscle_info.muscle_names,...
         mirrorName(model_info.muscle_info.muscle_names{i})));
+    if ~isempty(idx_mus_inv_i)
+        orderMusInv(i) = idx_mus_inv_i;
+    else
+        if strcmpi(S.misc.gaitmotion_type,'HalfGaitCycle')
+            error("Model asymmetry detected while S.misc.gaitmotion_type = " + ...
+                "'HalfGaitCycle'")
+        end
+    end
 end
 symQs.MusInvA = orderMus;
 symQs.MusInvB = orderMusInv;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Provide a short overview of the changes -->
Detecting left-right symmetry of muscles would throw an error if a muscle existed only on one side of the model.
Changed the code so it does not result in an error related to a missing index. 
In case of a half gait cycle simulation such models are not allowed, so then the code throws an error.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Models with asymmetric muscle names should be allowed for full gait cycle simulations. They are not allowed for half gait cycle simulations. Give a more meaningful error message.

## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
<!--- Please describe the outcome of these tests. -->
Ran test_PredSim, and both models passed the test.

## Suggested tests for reviewers
<!---Please describe tests for the reviewer to run -->


<!--- Assign labels ("Labels" tab in side bar). Each PR should have at least one "Review:..." label, since we use these to allocate reviewers. -->
<!--- Do not add requested reviewers, unless this person specifically agreed to review your PR. -->
<!--- If you are a collaborator (i.e. have direct write access to this repo) select yourself as assignee, otherwise someone will be assigned to your PR. -->
