### PR TITLE
bugfix settings

### DIFF
--- a/PlotFigures/plot_figure_grf.m
+++ b/PlotFigures/plot_figure_grf.m
@@ -30,7 +30,7 @@ function [fig_hand] = plot_figure_grf(R,varargin)
 % default color is blue
 colr = [0 0.4470 0.7410];
 % legend name
-legName = R.S.post_process.result_filename;
+legName = R.S.misc.result_filename;
 % use no interpreter for legend
 lgInt = 'none';
 

--- a/PlotFigures/plot_figure_template.m
+++ b/PlotFigures/plot_figure_template.m
@@ -29,7 +29,7 @@ function [fig_hand] = plot_figure_template(R,varargin)
 % default color is blue
 colr = [0 0.4470 0.7410];
 % default legend name is filename
-legName = R.S.post_process.result_filename;
+legName = R.S.misc.result_filename;
 % by default, use no interpreter for legend, because default name contains "_"
 legInt = 'none';
 

--- a/PlotFigures/plot_figures.m
+++ b/PlotFigures/plot_figures.m
@@ -42,7 +42,7 @@ for i=1:length(result_paths)
     load(result_paths{i},'R','model_info');
 
     if length(legend_names)<i
-        legend_names{i} = replace(R.S.post_process.result_filename,'_',' ');
+        legend_names{i} = replace(R.S.misc.result_filename,'_',' ');
     end
     
     % loop over figures


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->
Replace `R.S.post_process.result_filename` with `R.S.misc.result_filename`.

## Description
<!--- Provide a short overview of the changes -->
Replace `R.S.post_process.result_filename` with `R.S.misc.result_filename` in the provided plotting functions.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
In #144 this setting was changed, but not carried through to the plotting functions.

## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
<!--- Please describe the outcome of these tests. -->
Run `plot_figure_grf.m` with a result of a simulation ran after https://github.com/KULeuvenNeuromechanics/PredSim/commit/339e5ee69f92e8a068e321fc2dd330bc46487d2f

## Suggested tests for reviewers
<!---Please describe tests for the reviewer to run -->
Run `plot_figure_grf.m` with a result of a simulation ran after https://github.com/KULeuvenNeuromechanics/PredSim/commit/339e5ee69f92e8a068e321fc2dd330bc46487d2f

<!--- Assign labels ("Labels" tab in side bar). Each PR should have at least one "Review:..." label, since we use these to allocate reviewers. -->
<!--- Do not add requested reviewers, unless this person specifically agreed to review your PR. -->
<!--- If you are a collaborator (i.e. have direct write access to this repo) select yourself as assignee, otherwise someone will be assigned to your PR. -->

Closes #204 
