### PR TITLE
Update get_git_hash.m

### DIFF
--- a/DefaultSettings/get_git_hash.m
+++ b/DefaultSettings/get_git_hash.m
@@ -24,7 +24,7 @@ function [local_hash, branch_name, remote_hash] = get_git_hash(pathRepo)
 % Original date: 28/02/2023
 %
 % Last edit by: Bram Van Den Bosch
-% Last edit date: 16/09/2025
+% Last edit date: 16/10/2025
 % --------------------------------------------------------------------------
 
 % save current working directory
@@ -33,17 +33,18 @@ pathInitDir = pwd;
 cd(pathRepo)
 
 % fetch latest refs from remote
-system('git fetch');
+[status,response] = system('git fetch');
 
-% get hash of the local instance
-[status,local_hash] = system('git rev-parse HEAD');
-local_hash = strtrim(local_hash);
-
-if contains(local_hash,"'git' is not recognized as an internal or external command")
+% check if git works
+if contains(response,"'git' is not recognized as an internal or external command")
     warning('Unable to get git hash. Git seems not to be installed on your machine or cannot be executed from the command line.');
 elseif status ~= 0 
     warning('Unable to get git hash. It is advised to get PredSim through GitHub to have version control and to receive future updates.');
 end
+
+% get hash of the local instance
+[status,local_hash] = system('git rev-parse HEAD');
+local_hash = strtrim(local_hash);
 
 if status == 0
     % get name of the current branch


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Provide a short overview of the changes -->
When you have a PR as local, the code would give a warning that is incorrect. Furthermore, the code did not fetch the latest version of the remote when run. Therefore, the following was changed.

- fetch at the beginning
- use less lines of code
- account for possible trailing newline with strtrim
- account for the local branch possibly being a PR

## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
<!--- Please describe the outcome of these tests. -->
Tested when a pr (pr/195) is my active local branch as well as when master is my local.
For both, it resulted in the expected outcome.

## Suggested tests for reviewers
<!---Please describe tests for the reviewer to run -->
Test with:
- a pr being you local branch
- a local branch that is behind the remote

<!--- Assign labels ("Labels" tab in side bar). Each PR should have at least one "Review:..." label, since we use these to allocate reviewers. -->
<!--- Do not add requested reviewers, unless this person specifically agreed to review your PR. -->
<!--- If you are a collaborator (i.e. have direct write access to this repo) select yourself as assignee, otherwise someone will be assigned to your PR. -->
