### PR TITLE
Small update in OCP_formulation.m (muscle synergies)

### DIFF
--- a/OCP/OCP_formulation.m
+++ b/OCP/OCP_formulation.m
@@ -570,8 +570,6 @@ end % End loop over collocation points
 if (S.subject.synergies) && (S.subject.TrackSynW)
     J_TrackSynW = W.TrackSynW*f_casadi.TrackSynW(SynW_rk, SynW_lk);
     J = J + J_TrackSynW;
-else
-    J_TrackSynW = 0;
 end
 
 % Synergies: a - WH = 0


### PR DESCRIPTION
## Description
Remove two lines in code that are not needed (they were used to assign a zero value to a variable that is not used later)

## How Has This Been Tested?
- 2D model: without synergies, with synergies but without tracking weights, with synergies and tracking weights
- 3D model: without synergies

## Suggested tests for reviewers
I don't think that a test is needed, just to revise the lines that have been removed.
