### PR TITLE
Orthosis optimization and state variables with custom dynamics

### DIFF
--- a/CasadiFunctions/createCasadi_orthosis.m
+++ b/CasadiFunctions/createCasadi_orthosis.m
@@ -44,7 +44,7 @@ F_all = F.map(S.solver.N_meshes,S.solver.parallel_mode,S.solver.N_threads);
 
 model_info.ExtFunIO.nOutputs = F.size1_out(0);
 
-for N = [1,S.solver.N_meshes]
+for N = [S.solver.N_meshes,1] %changed to first do N=Nmeshes
 
 
 %% Define variables
@@ -55,9 +55,13 @@ qddot_SX = SX.sym('qddot',n_coord,N);
 act_SX = SX.sym('a',model_info.muscle_info.NMuscle,N);
 fromExtFun_SX = SX.sym('fromExtFun',F.size1_out(0),N); % GRFs, point kinematics
 
+orthStates_SX = SX.sym('x',length(S.orthosis.stateNames_all),N);
+orthControls_SX = SX.sym('u',length(S.orthosis.controlNames_all),N);
+
 % all outputs
 Mcoordk_SX = SX(n_coord,N);
 toExtFun_SX = SX(F.size1_in(0),N); % bodyforces, bodymoments
+stateDyn_SX = SX(S.orthosis.Nstates_all,N);
 
 
 %% loop over all selected orthoses
@@ -71,30 +75,55 @@ if ~isempty(S.orthosis)
 
             % Get casadi Function of this orthosis
             [f_orthosis_i, f_orthosis_pp_i] =...
-                orthosis_i.wrapCasadiFunction(model_info.ExtFunIO,model_info.muscle_info.muscle_names);
+                orthosis_i.wrapCasadiFunction(model_info.ExtFunIO,model_info.muscle_info.muscle_names,S.orthosis.stateNames_all,S.orthosis.controlNames_all);
 
             % Add to struct for post-processing
             separate_orthoses(i).wrap = f_orthosis_i;
             separate_orthoses(i).wrap_pp = f_orthosis_pp_i;
 
-            % evaluate function
-            [Mcoordk_i, toExtFun_i] = f_orthosis_i(q_SX,qdot_SX,qddot_SX,act_SX,fromExtFun_SX);
-
+            % evaluate function 
+            [Mcoordk_i, toExtFun_i, stateDyn_i] = f_orthosis_i(q_SX,qdot_SX,qddot_SX,act_SX,fromExtFun_SX,orthStates_SX,orthControls_SX);
+            
             % accumulate outputs
             Mcoordk_SX = Mcoordk_SX + Mcoordk_i;
             toExtFun_SX = toExtFun_SX + toExtFun_i;
+            stateDyn_SX = stateDyn_SX + stateDyn_i; % Each orthosis uniquely defines a subset of x_dot, zero otherwise
 
+            % create Casadi function for orthosis state dynamics
+            separate_orthoses(i).dynamics = Function(['f_Orthosis_dynamics_',num2str(N)],...
+                {q_SX, qdot_SX, qddot_SX, act_SX, fromExtFun_SX,orthStates_SX,orthControls_SX},...
+                {stateDyn_i},...
+                {'qs','qdots','qddots','act','fromExtFun','orthStates','orthControls'},...
+                {'orthStateDyn'});                       
         end
     end
 end
 
 
 %% create casadi Function for combination of orthoses
-fun = Function(['f_Orthosis_mesh_',num2str(N),'_wo_ext'],...
-    {q_SX, qdot_SX, qddot_SX, act_SX, fromExtFun_SX},...
-    {Mcoordk_SX, toExtFun_SX},...
-    {'qs','qdots','qddots','act','fromExtFun'},...
-    {'M_coord','toExtFun'});
+if Nmesh==N
+    fun = Function(['f_Orthosis_mesh_',num2str(N),'_wo_ext'],...
+        {q_SX, qdot_SX, qddot_SX, act_SX, fromExtFun_SX,orthStates_SX,orthControls_SX},...
+        {Mcoordk_SX, toExtFun_SX,stateDyn_SX},...
+        {'qs','qdots','qddots','act','fromExtFun','orthStates','orthControls'},...
+        {'M_coord','toExtFun','stateDyn'});
+else
+    % call function with Nmesh rows in the arguments
+    [res_Mcoordk_SX, res_toExtFun_SX, res_stateDyn_SX] = fun(repmat(q_SX,1,Nmesh),repmat(qdot_SX,1,Nmesh),...
+        repmat(qddot_SX,1,Nmesh),repmat(act_SX,1,Nmesh),...
+        repmat(fromExtFun_SX,1,Nmesh),repmat(orthStates_SX,1,Nmesh),...
+        repmat(orthControls_SX,1,Nmesh));
+    res_Mcoordk_SX_1 = res_Mcoordk_SX(:,1);
+    res_toExtFun_SX_1 = res_toExtFun_SX(:,1);
+    res_stateDyn_SX_1 = res_stateDyn_SX(:,1);
+    % redefine mapping fun
+    fun = Function(['f_Orthosis_mesh_',num2str(N),'_wo_ext'],...
+        {q_SX, qdot_SX, qddot_SX, act_SX, fromExtFun_SX,orthStates_SX,orthControls_SX},...
+        {res_Mcoordk_SX_1, res_toExtFun_SX_1,res_stateDyn_SX_1},...
+        {'qs','qdots','qddots','act','fromExtFun','orthStates','orthControls'},...
+        {'M_coord','toExtFun','stateDyn'});
+
+end
 
 %% Create casadi Function for combination of orthoses, and include external function
 % inputs
@@ -103,6 +132,9 @@ qdots_MX = MX.sym('qdots',n_coord,N);
 qddots_MX = MX.sym('qddots',n_coord,N);
 act_MX = MX.sym('a',model_info.muscle_info.NMuscle,N);
 
+orthStates_MX = MX.sym('x',S.orthosis.Nstates_all,N);
+orthControls_MX = MX.sym('u',S.orthosis.Ncontrols_all,N);
+stateDyn_MX = MX.sym('x_dot',S.orthosis.Nstates_all,N);
 
 % Create zero (sparse) input vector for external function
 F_ext_input = MX(model_info.ExtFunIO.input.nInputs,N);
@@ -120,27 +152,32 @@ else
 end
 
 % Evaluate orthosis function
-[Mcoord_MX, toExtFun_MX] = fun(qs_MX,qdots_MX,qddots_MX,act_MX,fromExtFun_MX);
+[Mcoord_MX, toExtFun_MX, stateDyn_MX] = fun(qs_MX,qdots_MX,qddots_MX,act_MX,fromExtFun_MX,orthStates_MX,orthControls_MX);
 
 % Create function to be used in OCP formulation
 if N==1
-    f_orthosis_mesh_k = Function('f_orthosis_mesh_k',{qs_MX,qdots_MX,qddots_MX,act_MX},...
-        {Mcoord_MX, toExtFun_MX},{'qs','qdots','qddots','act'},{'M_coord','M_body'});
+    f_orthosis_mesh_k = Function('f_orthosis_mesh_k',{qs_MX,qdots_MX,qddots_MX,act_MX,orthStates_MX,orthControls_MX},...
+        {Mcoord_MX, toExtFun_MX, stateDyn_MX},{'qs','qdots','qddots','act','orthStates','orthControls'},{'M_coord','M_body','stateDyn'});
 else
-    f_orthosis_mesh_all = Function('f_orthosis_mesh_all',{qs_MX,qdots_MX,qddots_MX,act_MX},...
-        {Mcoord_MX, toExtFun_MX},{'qs','qdots','qddots','act'},{'M_coord','M_body'});
+    f_orthosis_mesh_all = Function('f_orthosis_mesh_all',{qs_MX,qdots_MX,qddots_MX,act_MX,orthStates_MX,orthControls_MX},...
+        {Mcoord_MX, toExtFun_MX, stateDyn_MX},{'qs','qdots','qddots','act','orthStates','orthControls'},{'M_coord','M_body','stateDyn'});
 end
 
 end % for N = [1, Nmeshes]
 
 %% Cleanup
+%TODO: this section was commented out, removal of object must be postponed
+% until after orthosis NLP vars and constraints have been added dynamically
+% in OCP_formulation.m
+
 % delete Orthosis objects, because we don't need them anymore and don't want to save it
 % note: might want to handle this more cleanly
-if ~isempty(S.orthosis)
-    for i=1:length(S.orthosis.settings)
-%         S.orthosis.settings{i} = rmfield(S.orthosis.settings{i},'object');
-        S.orthosis.settings{i}.object.delete();
-    end
-end
+% if ~isempty(S.orthosis)
+%     for i=1:length(S.orthosis.settings)
+% %         S.orthosis.settings{i} = rmfield(S.orthosis.settings{i},'object');
+%         S.orthosis.settings{i}.object.delete();
+%     end
+% end
+
 
 end % end of function

--- a/OCP/OCP_formulation.m
+++ b/OCP/OCP_formulation.m
@@ -569,24 +569,26 @@ for j=1:d
     
 
     %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-    f_orthosis_mesh_k_retvals = cell(1,3);
-    % Orthosis moments on collocation point
-    [f_orthosis_mesh_k_retvals{:}] = f_casadi.f_orthosis_mesh_k(Qskj_nsc(:,j+1),...
-    Qdotskj_nsc(:,j+1), Aj_nsc(:,j), akj(:,j+1), ortArg_nsc{:});
 
     if ortstatespresent 
-            % add orthosis moments from input variables (interlaced)
-            M_ort_coord_totj = M_ort_coordk(:,j) + f_orthosis_mesh_k_retvals{1};
-            M_ort_body_totj = M_ort_bodyk(:,j) + f_orthosis_mesh_k_retvals{2};
+            % Orthosis moments on collocation point
+            [M_ort_coordj, M_ort_bodyj, xdot] = f_casadi.f_orthosis_mesh_k(Qskj_nsc(:,j+1),...
+            Qdotskj_nsc(:,j+1), Aj_nsc(:,j), akj(:,j+1), ortArg_nsc{:});
+            % add orthosis moments from input variables (interlaced) 
+            % one of the terms is always zero
+            M_ort_coord_totj = M_ort_coordk(:,j) + M_ort_coordj;
+            M_ort_body_totj = M_ort_bodyk(:,j) + M_ort_bodyj;
         if (~S.orthosis.isTimeVariable)
-            eq_constr{end+1} = (h*f_orthosis_mesh_k_retvals{3} - xp_nsc)./scaling_factors(x_exo_bounds,x_exo_bounds_nsc);
+            eq_constr{end+1} = (h*xdot - xp_nsc)./scaling_factors(x_exo_bounds,x_exo_bounds_nsc);
         else
             eq_constr{end+1} = (h*xdotj(:,j) - xp_nsc)./scaling_factors(x_exo_bounds,x_exo_bounds_nsc);
         end
     else
+        [M_ort_coordj, M_ort_bodyj] = f_casadi.f_orthosis_mesh_k(Qskj_nsc(:,j+1),...
+        Qdotskj_nsc(:,j+1), Aj_nsc(:,j), akj(:,j+1), ortArg_nsc{:});
         % add orthosis moments from input variables
-        M_ort_coord_totj = M_ort_coordk + f_orthosis_mesh_k_retvals{1};
-        M_ort_body_totj = M_ort_bodyk + f_orthosis_mesh_k_retvals{2};
+        M_ort_coord_totj = M_ort_coordk + M_ort_coordj;
+        M_ort_body_totj = M_ort_bodyk + M_ort_bodyj;
     end
 
     %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/PlotFigures/plot_figure_orthosis.m
+++ b/PlotFigures/plot_figure_orthosis.m
@@ -51,15 +51,30 @@ for i = 1:length(varargin)
     end
 end
 
-%% Determine figure
+%% Determine figure (updated for subplots)
 if ~exist('fig_hand','var') || isempty(fig_hand)
     fig_hand = figure('Name','Orthosis signals');
 end
 
-% Create axes explicitly
-ax = axes(fig_hand); 
-hold(ax,'on');
+% === NEW SECTION: safely add a new subplot each call ===
+existingAxes = findobj(fig_hand, 'Type', 'axes');
+nAx = numel(existingAxes);
 
+% Compute normalized height per axis
+axHeight = 1 / (nAx + 1);
+axMargin = 0.05; % small gap between axes
+
+% Reposition existing axes to make room for the new one
+for k = 1:nAx
+    set(existingAxes(nAx - k + 1), ...
+        'Position', [0.13, axMargin + k*axHeight, 0.82, axHeight - axMargin]);
+end
+
+% Create new axes at the bottom for the next plot
+axBottom = [0.13, axMargin, 0.82, axHeight - axMargin];
+ax = axes('Parent', fig_hand, 'Position', axBottom);
+hold(ax, 'on');
+% ======================================================
 
 % Use number of mesh points from solver instead of relying on orthosis.states (may not exist)
 percentage_gait_cycle = linspace(0,100,R.S.solver.N_meshes);
@@ -144,19 +159,11 @@ for i = 1:length(namesToPlot)
 end
 
 %% Format axes
-xlabel('Gait cycle (%)')
-ylabel('Value')
-title(legName, 'Interpreter','none')
+xlabel(ax,'Gait cycle (%)')
+ylabel(ax,'Value')
+title(ax,legName, 'Interpreter','none')
 legend(ax,'Location','best','Interpreter',legInt)
-grid on
-box on
+grid(ax,'on')
+box(ax,'on')
 
 end
-
-
-
-
-
-
-
-

--- a/PlotFigures/plot_figure_orthosis.m
+++ b/PlotFigures/plot_figure_orthosis.m
@@ -1,0 +1,162 @@
+function [fig_hand] = plot_figure_orthosis(R, namesToPlot, varargin)
+% --------------------------------------------------------------------------
+% plot_figure_template
+%   Plots orthosis states, controls, and/or exoskeleton joint torques
+% 
+% INPUT:
+%   - R -
+%   * struct with simulation results
+%
+%   - namesToPlot -
+%   * cell array of strings (names of orthosis states, controls, or DOFs)
+%
+%   - optional inputs - 
+%   * pass a figure handle to add plots to an existing figure, otherwise
+%       this function will make a new figure
+%   * pass an array of 3 doubles to use as RGB triplet for the new plot
+%   * pass a string to use as name in the legend
+%
+% OUTPUT:
+%   - fig_hand -
+%   * handle of the plotted figure
+%
+% Original author: Lars D'Hondt
+% Original date: 24/May/2022
+%
+% Last edit by: ChatGPT (GPT-5)
+% Last edit date: 21/Oct/2025
+% --------------------------------------------------------------------------
+
+%% Early exit if no orthosis data
+if ~isfield(R, 'orthosis') || isempty(R.orthosis)
+    warning('R.orthosis does not exist. Exiting plot_figure_orthosis without plotting.');
+    fig_hand = []; % return empty handle
+    return
+end
+
+%% Default settings
+colr = [];
+legName = R.S.misc.result_filename;
+legInt = 'none';
+
+%% Input parsing
+for i = 1:length(varargin)
+    if isa(varargin{i},'matlab.ui.Figure')
+        fig_hand = varargin{i};
+    elseif isa(varargin{i},'double') && length(varargin{i})==3
+        colr = varargin{i};
+    elseif isa(varargin{i},'string') || isa(varargin{i},'char')
+        legName = varargin{i};
+        legInt = 'tex';
+    end
+end
+
+%% Determine figure
+if ~exist('fig_hand','var') || isempty(fig_hand)
+    fig_hand = figure('Name','Orthosis signals');
+end
+
+% Create axes explicitly
+ax = axes(fig_hand); 
+hold(ax,'on');
+
+
+% Use number of mesh points from solver instead of relying on orthosis.states (may not exist)
+percentage_gait_cycle = linspace(0,100,R.S.solver.N_meshes);
+
+% available names
+if isfield(R, 'S') && isfield(R.S, 'orthosis')
+    if isfield(R.S.orthosis, 'stateNames_all')
+        stateNames = R.S.orthosis.stateNames_all;
+    else
+        stateNames = {};
+    end
+    if isfield(R.S.orthosis, 'controlNames_all')
+        controlNames = R.S.orthosis.controlNames_all;
+    else
+        controlNames = {};
+    end
+else
+    stateNames = {};
+    controlNames = {};
+end
+
+if isfield(R, 'colheaders') && isfield(R.colheaders, 'coordinates')
+    coordNames = R.colheaders.coordinates; % used for T_coord matching
+else
+    coordNames = {};
+end
+
+%% Prepare default color cycling
+defaultColors = get(gca,'ColorOrder');
+nColors = size(defaultColors,1);
+
+%% Loop through requested names
+for i = 1:length(namesToPlot)
+    name = namesToPlot{i};
+    data = [];
+    src  = '';
+
+    % --- match in orthosis states
+    idx_state = find(strcmp(name, stateNames));
+    if ~isempty(idx_state)
+        data = R.orthosis.states(:, idx_state);
+        src = 'state';
+    end
+
+    % --- match in orthosis controls
+    if isempty(data)
+        idx_ctrl = find(strcmp(name, controlNames));
+        if ~isempty(idx_ctrl)
+            data = R.orthosis.controls(:, idx_ctrl);
+            src = 'control';
+        end
+    end
+
+    % --- match in combined torques (T_coord)
+    if isempty(data) && isfield(R.orthosis,'combined') && ...
+            isfield(R.orthosis.combined,'T_coord')
+        % like plot_figure_generic, look for exact match in coordinate headers
+        idx_torque = find(strcmp(R.colheaders.coordinates, name));
+        if ~isempty(idx_torque)
+            data = R.orthosis.combined.T_coord(:, idx_torque);
+            src = 'exo torque';
+        end
+    end
+
+    % --- handle not found
+    if isempty(data)
+        warning('Name "%s" not found in states, controls, or DOFs.', name);
+        continue;
+    end
+
+    % Determine color
+    if isempty(colr)
+        colorToUse = defaultColors(mod(i-1,nColors)+1, :);
+    else
+        colorToUse = colr;
+    end
+
+    % --- plot data
+    plot(percentage_gait_cycle, data, ...
+        'DisplayName', sprintf('%s (%s)', name, src), ...
+        'Color', colorToUse, 'LineWidth', 1.5);
+end
+
+%% Format axes
+xlabel('Gait cycle (%)')
+ylabel('Value')
+title(legName, 'Interpreter','none')
+legend('Location','best','Interpreter',legInt)
+grid on
+box on
+
+end
+
+
+
+
+
+
+
+

--- a/PlotFigures/plot_figure_orthosis.m
+++ b/PlotFigures/plot_figure_orthosis.m
@@ -23,7 +23,7 @@ function [fig_hand] = plot_figure_orthosis(R, namesToPlot, varargin)
 % Original author: Lars D'Hondt
 % Original date: 24/May/2022
 %
-% Last edit by: ChatGPT (GPT-5)
+% Last edit by: Sander De Groof
 % Last edit date: 21/Oct/2025
 % --------------------------------------------------------------------------
 
@@ -138,7 +138,7 @@ for i = 1:length(namesToPlot)
     end
 
     % --- plot data
-    plot(percentage_gait_cycle, data, ...
+    plot(ax,percentage_gait_cycle, data, ...
         'DisplayName', sprintf('%s (%s)', name, src), ...
         'Color', colorToUse, 'LineWidth', 1.5);
 end
@@ -147,7 +147,7 @@ end
 xlabel('Gait cycle (%)')
 ylabel('Value')
 title(legName, 'Interpreter','none')
-legend('Location','best','Interpreter',legInt)
+legend(ax,'Location','best','Interpreter',legInt)
 grid on
 box on
 

--- a/PlotFigures/plot_figures.m
+++ b/PlotFigures/plot_figures.m
@@ -23,8 +23,8 @@ function [] = plot_figures(result_paths,legend_names,figure_settings)
 % Original author: Lars D'Hondt
 % Original date: 20/May/2022
 %
-% Last edit by: 
-% Last edit date: 
+% Last edit by: Sander De Groof
+% Last edit date: 21/Oct/2025
 % --------------------------------------------------------------------------
 
 % generate colours, in this case a rainbow
@@ -48,11 +48,22 @@ for i=1:length(result_paths)
     % loop over figures
     for j=1:length(figure_settings)
         % check figure type
-        if strcmp(figure_settings(j).dofs,'custom')
+        % >>> CHANGED: also allow orthosis variable to trigger custom handling
+        if any(strcmp(figure_settings(j).dofs,'custom')) || any(strcmp(figure_settings(j).variables,'orthosis'))
             % use custom figure function
             if strcmp(figure_settings(j).variables,'GRF')
                 % use "plot_figure_grf.m"
                 fig_hands{j} = plot_figure_grf(R,legend_names{i},colors(i,:),fig_hands{j});
+
+            % >>> ADDED: call new orthosis plotting function
+            elseif strcmp(figure_settings(j).variables,'orthosis')
+                % use "plot_figure_orthosis.m"
+                % plots orthosis states, controls, or exo torques
+                fig_hands{j} = plot_figure_orthosis(R, ...
+                    figure_settings(j).dofs, ...   % names of orthosis vars or DOFs
+                    fig_hands{j}, ...              % figure handle (colors default cycle)
+                    legend_names{i});              % legend label
+            % >>> END ADDITION
 
             elseif strcmp(figure_settings(j).variables,'my_first_figure')
                 % call you custom figure function here
@@ -123,6 +134,4 @@ for j=1:length(figure_settings)
         end
     end
 end
-
-
 

--- a/PlotFigures/run_this_file_to_plot_figures.m
+++ b/PlotFigures/run_this_file_to_plot_figures.m
@@ -14,8 +14,9 @@ clc
 % Construct a cell array with full paths to files with saved results for
 % which you want to appear on the plotted figures.
 results_folder = fullfile(pathRepoFolder,'PredSimResults');
-result_paths{1} = fullfile(pathRepo,'Tests','ReferenceResults','Falisse_et_al_2022','Falisse_et_al_2022_paper.mat');
-% result_paths{2} = fullfile(results_folder,'Falisse_et_al_2022_Results','Falisse_et_al_2022_v1.mat');
+%result_paths{1} = fullfile(pathRepo,'Tests','ReferenceResults','Falisse_et_al_2022','Falisse_et_al_2022_paper.mat');
+result_paths{1} = fullfile(results_folder,'Falisse_et_al_2022','Falisse_et_al_2022_v21.mat');
+result_paths{2} = fullfile(results_folder,'Falisse_et_al_2022','Falisse_et_al_2022_v23.mat');
 
 
 % Cell array with legend name for each result
@@ -125,6 +126,12 @@ fig_count = fig_count+1;
 % figure_settings(fig_count).filetype = {};
 % fig_count = fig_count+1;
 
+figure_settings(fig_count).name = 'orthosis_signals';
+figure_settings(fig_count).dofs = {'hip_flexion_l', 'control_u_l_side', 'state_x_l_side'};
+figure_settings(fig_count).variables = {'orthosis'};  % <--- this triggers plot_figure_orthosis
+figure_settings(fig_count).savepath = fullfile(figure_folder,[figure_savename '_orthosis']);
+figure_settings(fig_count).filetype = {'png'};
+fig_count = fig_count + 1;
 %%
 
 plot_figures(result_paths,legend_names,figure_settings);

--- a/PostProcessing/PostProcess_orthosis.m
+++ b/PostProcessing/PostProcess_orthosis.m
@@ -31,15 +31,19 @@ qs(R.ground_reaction.idx_GC,:) = R.kinematics.Qs_rad;
 qdots(R.ground_reaction.idx_GC,:) = R.kinematics.Qdots_rad;
 qddots(R.ground_reaction.idx_GC,:) = R.kinematics.Qddots_rad;
 acts(R.ground_reaction.idx_GC,:) = R.muscles.a;
+states(R.ground_reaction.idx_GC,:) = R.orthosis.states;
+controls(R.ground_reaction.idx_GC,:) = R.orthosis.controls;
 
 qs = qs(1:N,:);
 qdots = qdots(1:N,:);
 qddots = qddots(1:N,:);
 acts = acts(1:N,:);
+states = states(1:N,:);
+controls = controls(1:N,:);
 
-[Mcoord1, toExtFun1] = f_casadi.f_orthosis_mesh_k(qs', qdots', qddots', acts');
+[Mcoord1, toExtFun1] = f_casadi.f_orthosis_mesh_k(qs', qdots', qddots', acts',states',controls');
 
-[Mcoord2, toExtFun2] = f_casadi.f_orthosis_mesh_all(qs',qdots',qddots',acts');
+[Mcoord2, toExtFun2] = f_casadi.f_orthosis_mesh_all(qs',qdots',qddots',acts',states',controls');
 
 
 F  = external('F',replace(fullfile(R.S.misc.subject_path,R.S.misc.external_function),'\','/'));
@@ -82,7 +86,7 @@ for i=1:length(f_casadi.separate_orthoses)
 
     res_fun = cell(1,f_pp_i.n_out);
 
-    [res_fun{:}] = f_pp_i(qs', qdots', qddots', acts',fromExtFun);
+    [res_fun{:}] = f_pp_i(qs', qdots', qddots', acts',fromExtFun,states',controls');
 
     for j=1:f_pp_i.n_out
         res_pp.x = full(res_fun{j});

--- a/PostProcessing/PostProcess_orthosis.m
+++ b/PostProcessing/PostProcess_orthosis.m
@@ -31,19 +31,29 @@ qs(R.ground_reaction.idx_GC,:) = R.kinematics.Qs_rad;
 qdots(R.ground_reaction.idx_GC,:) = R.kinematics.Qdots_rad;
 qddots(R.ground_reaction.idx_GC,:) = R.kinematics.Qddots_rad;
 acts(R.ground_reaction.idx_GC,:) = R.muscles.a;
-states(R.ground_reaction.idx_GC,:) = R.orthosis.states;
-controls(R.ground_reaction.idx_GC,:) = R.orthosis.controls;
+
+ortArg = {};
+if isfield(R,'orthosis')
+    if isfield(R.orthosis,'states')
+        states(R.ground_reaction.idx_GC,:) = R.orthosis.states;
+        states = states(1:N,:);
+        ortArg{end+1} = states';
+    end
+    if isfield(R.orthosis,'controls')
+        controls(R.ground_reaction.idx_GC,:) = R.orthosis.controls;
+        controls = controls(1:N,:);
+        ortArg{end+1} = controls';
+    end
+end
 
 qs = qs(1:N,:);
 qdots = qdots(1:N,:);
 qddots = qddots(1:N,:);
 acts = acts(1:N,:);
-states = states(1:N,:);
-controls = controls(1:N,:);
 
-[Mcoord1, toExtFun1] = f_casadi.f_orthosis_mesh_k(qs', qdots', qddots', acts',states',controls');
+[Mcoord1, toExtFun1] = f_casadi.f_orthosis_mesh_k(qs', qdots', qddots', acts',ortArg{:});
 
-[Mcoord2, toExtFun2] = f_casadi.f_orthosis_mesh_all(qs',qdots',qddots',acts',states',controls');
+[Mcoord2, toExtFun2] = f_casadi.f_orthosis_mesh_all(qs',qdots',qddots',acts',ortArg{:});
 
 
 F  = external('F',replace(fullfile(R.S.misc.subject_path,R.S.misc.external_function),'\','/'));
@@ -86,7 +96,7 @@ for i=1:length(f_casadi.separate_orthoses)
 
     res_fun = cell(1,f_pp_i.n_out);
 
-    [res_fun{:}] = f_pp_i(qs', qdots', qddots', acts',fromExtFun,states',controls');
+    [res_fun{:}] = f_pp_i(qs', qdots', qddots', acts',fromExtFun,ortArg{:});
 
     for j=1:f_pp_i.n_out
         res_pp.x = full(res_fun{j});

--- a/PreProcessing/finaliseOrthosisDefinitions.m
+++ b/PreProcessing/finaliseOrthosisDefinitions.m
@@ -24,8 +24,8 @@ function [S] = finaliseOrthosisDefinitions(S, osim_path)
 init.Nmesh = S.solver.N_meshes;
 init.osimPath = osim_path;
 
-statecounter = uint16(0);
-controlcounter = uint16(0);
+statecounter = uint32(0);
+controlcounter = uint32(0);
 % first loop: assemble cellstring of all orthosis states and controls
 for i=1:length(S.orthosis.settings)
     orthosis_settings_i = S.orthosis.settings{i};
@@ -44,7 +44,7 @@ for i=1:length(S.orthosis.settings)
         S.orthosis.settings{i}.states.names = {meta_arg(isX).name};
         S.orthosis.settings{i}.states.bounds_nsc = {meta_arg(isX).bounds_nsc};
         S.orthosis.settings{i}.states.bounds = {meta_arg(isX).bounds};
-        statecounter = statecounter + uint16(1);
+        statecounter = statecounter + uint32(1);
     else
         S.orthosis.settings{i}.states.names = {};
         S.orthosis.settings{i}.states.bounds_nsc = {};
@@ -56,7 +56,7 @@ for i=1:length(S.orthosis.settings)
         S.orthosis.settings{i}.controls.names = {meta_arg(isU).name};
         S.orthosis.settings{i}.controls.bounds_nsc = {meta_arg(isU).bounds_nsc};
         S.orthosis.settings{i}.controls.bounds = {meta_arg(isU).bounds};
-        controlcounter = controlcounter + uint16(1);
+        controlcounter = controlcounter + uint32(1);
     else
         S.orthosis.settings{i}.controls.names = {};
         S.orthosis.settings{i}.controls.bounds_nsc = {};

--- a/PreProcessing/finaliseOrthosisDefinitions.m
+++ b/PreProcessing/finaliseOrthosisDefinitions.m
@@ -50,7 +50,7 @@ for i=1:length(S.orthosis.settings)
         S.orthosis.settings{i}.states.names = {meta_arg(isX).name};
         S.orthosis.settings{i}.states.bounds_nsc = {meta_arg(isX).bounds_nsc};
         S.orthosis.settings{i}.states.bounds = {meta_arg(isX).bounds};
-        statecounter = statecounter + uint32(1);
+        statecounter = statecounter + nnz(isX);
     else
         S.orthosis.settings{i}.states.names = {};
         S.orthosis.settings{i}.states.bounds_nsc = {};
@@ -62,7 +62,7 @@ for i=1:length(S.orthosis.settings)
         S.orthosis.settings{i}.controls.names = {meta_arg(isU).name};
         S.orthosis.settings{i}.controls.bounds_nsc = {meta_arg(isU).bounds_nsc};
         S.orthosis.settings{i}.controls.bounds = {meta_arg(isU).bounds};
-        controlcounter = controlcounter + uint32(1);
+        controlcounter = controlcounter + nnz(isU);
     else
         S.orthosis.settings{i}.controls.names = {};
         S.orthosis.settings{i}.controls.bounds_nsc = {};

--- a/PreProcessing/finaliseOrthosisDefinitions.m
+++ b/PreProcessing/finaliseOrthosisDefinitions.m
@@ -26,6 +26,7 @@ init.osimPath = osim_path;
 
 statecounter = uint32(0);
 controlcounter = uint32(0);
+S.orthosis.isTimeVariable = false;
 % first loop: assemble cellstring of all orthosis states and controls
 for i=1:length(S.orthosis.settings)
     orthosis_settings_i = S.orthosis.settings{i};
@@ -34,6 +35,11 @@ for i=1:length(S.orthosis.settings)
     fun = str2func(orthosis_settings_i.function_name);
     orthosis = fun(init, orthosis_settings_i);    
     S.orthosis.settings{i}.object = orthosis;
+    
+    % Flag that at least one orthosis is time variable
+    if orthosis.getNmesh() > 1
+        S.orthosis.isTimeVariable = true;
+    end
 
     [~,~,~,~,~,~,meta_arg,~] = getArgRes(orthosis);
 

--- a/PreProcessing/finaliseOrthosisDefinitions.m
+++ b/PreProcessing/finaliseOrthosisDefinitions.m
@@ -70,45 +70,47 @@ end
 settings = [S.orthosis.settings{:}];
 
 % Concatenate controlNames across all structs
-temp = [settings.controls];
-S.orthosis.controlNames_all = [temp.names]; 
-S.orthosis.controlBounds_nsc_all = [temp.bounds_nsc];
-S.orthosis.controlBounds_all = [temp.bounds];
-S.orthosis.Ncontrols_all = controlcounter;
-
-% Concatenate stateNames across all structs
-temp = [settings.states];
-%S.orthosis.Nstates_all = sum()
-S.orthosis.stateNames_all = [temp.names];
-S.orthosis.stateBounds_nsc_all = [temp.bounds_nsc];
-S.orthosis.stateBounds_all = [temp.bounds];
-S.orthosis.Nstates_all = statecounter;
-
-for i=1:length(S.orthosis.settings)
-
-    orthosis = S.orthosis.settings{i}.object;
-
-    orthosis.createCasadiFunction();
-    % run testing methods
-%     orthosis.setOsimPath(osim_path);
-%     orthosis.testOsimModel();
-
-    % Add OpenSimAD options required for orthosis
-    PointPositions = orthosis.getPointPositions();
-    S.OpenSimADOptions.export3DPositions = [S.OpenSimADOptions.export3DPositions(:);...
-        PointPositions(:)];
-    PointVelocities = orthosis.getPointVelocities();
-    S.OpenSimADOptions.export3DVelocities = [S.OpenSimADOptions.export3DVelocities(:);...
-        PointVelocities(:)];
-    BodyForces = orthosis.getBodyForces();
-    S.OpenSimADOptions.input3DBodyForces = [S.OpenSimADOptions.input3DBodyForces(:);...
-        BodyForces(:)];
-    BodyMoments = orthosis.getBodyMoments();
-    S.OpenSimADOptions.input3DBodyMoments = [S.OpenSimADOptions.input3DBodyMoments(:);...
-        BodyMoments(:)];
-
-    S.orthosis.settings{i}.object = orthosis;
+if ~isempty(settings)
+    temp = [settings.controls];
+    S.orthosis.controlNames_all = [temp.names]; 
+    S.orthosis.controlBounds_nsc_all = [temp.bounds_nsc];
+    S.orthosis.controlBounds_all = [temp.bounds];
+    S.orthosis.Ncontrols_all = controlcounter;
     
+    % Concatenate stateNames across all structs
+    temp = [settings.states];
+    %S.orthosis.Nstates_all = sum()
+    S.orthosis.stateNames_all = [temp.names];
+    S.orthosis.stateBounds_nsc_all = [temp.bounds_nsc];
+    S.orthosis.stateBounds_all = [temp.bounds];
+    S.orthosis.Nstates_all = statecounter;
+
+    for i=1:length(S.orthosis.settings)
+    
+        orthosis = S.orthosis.settings{i}.object;
+    
+        orthosis.createCasadiFunction();
+        % run testing methods
+    %     orthosis.setOsimPath(osim_path);
+    %     orthosis.testOsimModel();
+    
+        % Add OpenSimAD options required for orthosis
+        PointPositions = orthosis.getPointPositions();
+        S.OpenSimADOptions.export3DPositions = [S.OpenSimADOptions.export3DPositions(:);...
+            PointPositions(:)];
+        PointVelocities = orthosis.getPointVelocities();
+        S.OpenSimADOptions.export3DVelocities = [S.OpenSimADOptions.export3DVelocities(:);...
+            PointVelocities(:)];
+        BodyForces = orthosis.getBodyForces();
+        S.OpenSimADOptions.input3DBodyForces = [S.OpenSimADOptions.input3DBodyForces(:);...
+            BodyForces(:)];
+        BodyMoments = orthosis.getBodyMoments();
+        S.OpenSimADOptions.input3DBodyMoments = [S.OpenSimADOptions.input3DBodyMoments(:);...
+            BodyMoments(:)];
+    
+        S.orthosis.settings{i}.object = orthosis;
+        
+    end
 end
 
 %% Remove duplicate entries

--- a/WearableDevices/Orthosis.m
+++ b/WearableDevices/Orthosis.m
@@ -676,14 +676,16 @@ classdef Orthosis < handle
                 % loop over all optivars
                 if n ==1
                     current_optivar = optivar_names;
+                    current_value = value;
                 else
                     current_optivar = optivar_names{m};
+                    current_value = value(m,:);
                 end
                 [~] = validateOptivar(self, current_optivar);
                 F_name = [current_optivar, '_dot'];
     
                 if ~any(cellfun(@(x)strcmp(x,F_name), self.names_res))
-                    self.res{end+1} = value;
+                    self.res{end+1} = current_value;
                     self.names_res{end+1} = F_name;
                     self.meta_res(end+1).name = current_optivar;
                     self.meta_res(end).type = 'dyn'; % type and subtype fields can be used later for wrapping

--- a/WearableDevices/Orthosis.m
+++ b/WearableDevices/Orthosis.m
@@ -43,28 +43,28 @@ classdef Orthosis < handle
 % Original date: January 2024
 % --------------------------------------------------------------------------
 
-    properties(Access = protected)
+    properties (Access = protected)
 
         name = []; % name of the orthosis
         Nmesh = 1; % number of meshpoints used to describe the time-varying behaviour of the orthosis. Set to 1 if time-independent.
-
+        Nstates = uint16(0);
+        Ncontrols = uint16(0);
 
         arg = {}; % input arguments of CasADi Function describing orthosis mechanics
-        res = {}; % output arguments of CasADi Function describing orthosis mechanics
+        res = {}; % output arguments of CasADi Function describing orthosis mechanics (forces and moments)
         res_pp = {}; % output arguments for post-processing function
         names_arg = {}; % names of input arguments of CasADi Function describing orthosis mechanics
         names_res = {}; % names of output arguments of CasADi Function describing orthosis mechanics
         names_res_pp = {}; % names of post-processing output arguments
         meta_arg = []; % metadata of input arguments of CasADi Function describing orthosis mechanics
         meta_res = []; % metadata of output arguments of CasADi Function describing orthosis mechanics
+
         fun = []; % handle of CasADi Function
-
-
+        
         BodyForces = {}; % input3DBodyForces for OpenSimAD
         BodyMoments = {}; % input3DBodyMoments for OpenSimAD
         PointPositions = {}; % export3DPositions for OpenSimAD
-        PointVelocities = {}; % export3DVelocities for OpenSimAD
-        
+        PointVelocities = {}; % export3DVelocities for OpenSimAD        
 
         osimPath = []; % path to model file
         warningOsimPathNotSet = false; % only warn once that osimPath was not set.
@@ -141,6 +141,16 @@ classdef Orthosis < handle
             N_mesh = self.Nmesh;
         end
 
+        function N = getNstates(self)
+            % Get the number of states
+            N = self.Nstates;
+        end
+
+        function N = getNcontrols(self)
+            % Get the number of controls
+            N = self.Ncontrols;
+        end
+
         function fun = getFunction(self)
             % [internal] Get the CasADi Function describing the Orthosis
             if isempty(self.fun)
@@ -169,6 +179,17 @@ classdef Orthosis < handle
             PointVelocities = self.PointPositions;
         end
 
+        function [arg,res,res_pp,names_arg,names_res,names_res_pp,meta_arg,meta_res] = getArgRes(self)
+            arg = self.arg; % input arguments of CasADi Function describing orthosis mechanics
+            res = self.res; % output arguments of CasADi Function describing orthosis mechanics (forces and moments)
+            res_pp = self.res_pp; % output arguments for post-processing function
+            names_arg = self.names_arg; % names of input arguments of CasADi Function describing orthosis mechanics
+            names_res = self.names_res; % names of output arguments of CasADi Function describing orthosis mechanics
+            names_res_pp = self.names_res_pp; % names of post-processing output arguments
+            meta_arg = self.meta_arg; % metadata of input arguments of CasADi Function describing orthosis mechanics
+            meta_res = self.meta_res; % metadata of output arguments of CasADi Function describing orthosis mechanics
+        end
+
         function [] = setOsimPath(self,osimPath)
             arguments
                 self Orthosis
@@ -180,6 +201,54 @@ classdef Orthosis < handle
         end
 
     %% create a variable 
+    function varopti = var_opti(self,var_name,state_control,bounds,scaledbounds)
+            arguments
+                self Orthosis
+                var_name char
+                state_control char {mustBeMember(state_control,{'state','control'})};
+                bounds (1,2) double                
+                scaledbounds (1,2) double = [-1,1]
+            end
+            % Create a variable that will be optimized for. States are
+            % subject to user-defined dynamics (method "addDynamics")
+            %
+            % EXAMPLE
+            %
+            % INPUT:
+            %   - var_name - [char]
+            %   * Name of the variable
+            %   - state_control - [char]
+            %   * State or control variable
+            %
+            % OUTPUT:
+            %   - varopti - [1x1 variable]
+            %   * Variable
+            %
+
+            var_name_full = ['optivar_',var_name];
+            varopti = casadi.SX.sym(var_name_full,1,self.Nmesh);
+            self.arg{end+1} = varopti;
+            self.names_arg{end+1} = var_name_full;
+            %self.osimCoordsUsed{end+1} = 'bar';
+            self.meta_arg(end+1).name = var_name;
+            self.meta_arg(end).type = 'optivar';
+            switch state_control
+                case 'state'
+                    self.meta_arg(end).subtype = 'x';
+                    self.Nstates = self.Nstates + uint16(1);
+                case 'control'
+                    self.meta_arg(end).subtype = 'u';
+                    self.Ncontrols = self.Ncontrols + uint16(1);
+            end
+
+            if bounds(1)>= bounds(2)
+                error('bounds input must be: [lower, upper], and lower should not equal upper')
+            end
+            self.meta_arg(end).bounds_nsc = bounds;
+            self.meta_arg(end).bounds = scaledbounds;
+
+        end % end of var_opti
+        
         function coord = var_coord(self,osim_coord_name,pos_vel_acc)
             arguments
                 self Orthosis
@@ -555,6 +624,78 @@ classdef Orthosis < handle
             end
         end % end of addBodyMoment
 
+        function [] = addDynamics(self,value,optivar_names)
+            arguments
+                self Orthosis
+                value
+                optivar_names
+            end
+            % Add internal orthosis dynamics such as those of the actuator
+            % and its controller.
+            %
+            % EXAMPLE
+
+            %
+            % INPUT:
+            %   - value - n-by-N_mesh matrix of Casadi expressions 
+            %         for the derivatives of the states x_dot = f(x,u) =
+            %         value for the n-column vector of stated defined in
+            %           optivar_names
+            %       The expressions may include any "var" expression:
+            %       var_opti (control or state), var_coord, var_muscle,
+            %       etc...
+            %   - optivar_names - 
+            %     The expressions may include any "var" expression:
+            %       var_opti (control or state), var_coord, var_muscle,
+            %       etc...
+        
+            % --- Validate value ---
+            n = size(value,1);
+            length = size(value,2);
+            if ~isa(value,'casadi.SX')
+                error('value must be an array of CasADi.SX objects.');
+            end
+            if length~=self.Nmesh
+                error('Expected "%s" to have size %i columns, but it has %i columns',...
+                    inputname(2),self.Nmesh,length);
+            end
+        
+            % --- Validate optivar_names ---
+            if n == 1
+                if ~ischar(optivar_names)
+                    error('optivar_names must be a char when n == 1.');
+                end
+            else
+                if ~(iscellstr(optivar_names) && (isequal(size(optivar_names),[n,1]) || isequal(size(optivar_names),[1,n])))
+                    error('optivar_names must be a cell array of strings of size [n,1] or [1,n] when n > 0.');
+                end
+            end
+            
+
+            for m = 1:n
+                % loop over all optivars
+                if n ==1
+                    current_optivar = optivar_names;
+                else
+                    current_optivar = optivar_names{m};
+                end
+                [~] = validateOptivar(self, current_optivar);
+                F_name = [current_optivar, '_dot'];
+    
+                if ~any(cellfun(@(x)strcmp(x,F_name), self.names_res))
+                    self.res{end+1} = value;
+                    self.names_res{end+1} = F_name;
+                    self.meta_res(end+1).name = current_optivar;
+                    self.meta_res(end).type = 'dyn'; % type and subtype fields can be used later for wrapping
+                    self.meta_res(end).subtype = 'stateDyn';
+                else
+                    warning('Cannot add dynamics for state "%s" more than once, expression will be ignored.',...
+                    current_optivar);
+                end
+            end
+
+        end % end of addDynamics
+
     %% analysis
         function [] = addVarToPostProcessing(self,var,label)
             arguments
@@ -637,20 +778,23 @@ classdef Orthosis < handle
                 self.names_arg, [self.names_res, self.names_res_pp]);
         end
 
-        function [wrap_fun, wrap_fun_pp] = wrapCasadiFunction(self,ExtFunIO,muscleNames)
+        function [wrap_fun, wrap_fun_pp] = wrapCasadiFunction(self,ExtFunIO,muscleNames,stateNames,controlNames)
             arguments
                 self
                 ExtFunIO
                 muscleNames
+                stateNames
+                controlNames
             end
             % [internal] Wrap the CasADi Function of the orthosis for easy integration with PredSim
-            %
             % INPUTS:
             %   - ExtFunIO - [struct]
             %   * model_info.ExtFunIO
             %
             %   - muscleNames - [cell array of chars]
             %   * model_info.muscle_info.muscle_names
+            %   - stateNames - [cell array of chars]
+            %   - controlNames - [cell array of chars]
             %
             % OUTPUTS:
             %   - wrap_fun - [casadi.Function]
@@ -673,20 +817,34 @@ classdef Orthosis < handle
             arg_SX.act = SX.sym('a',length(muscleNames),self.Nmesh);
             arg_SX.fromExtFun = SX.sym('fromExtFun',ExtFunIO.nOutputs,self.Nmesh); % GRFs, point kinematics
 
+            arg_SX.x = SX.sym('optivar_x',length(stateNames), self.Nmesh); % orthosis internal state
+            arg_SX.u = SX.sym('optivar_u',length(controlNames), self.Nmesh); % orthosis controls (to be optimized)
+
             % all outputs for wrapper function
             res_SX.Mcoord = SX(ExtFunIO.jointi.nq.all,self.Nmesh);
             res_SX.toExtFun = SX(ExtFunIO.input.nInputs,self.Nmesh); % bodyforces, bodymoments
 
+            res_SX.stateDyn = SX(length(stateNames), self.Nmesh); % orthosis internal state dynamics
+
             % create inputs for function from inputs of wrapper function
             arg_fun = cell(1,self.fun.n_in);
             res_fun = cell(1,self.fun.n_out);
+
             for j=1:length(arg_fun)
-                if strcmp(self.meta_arg(j).type,'muscle')
-                    idx = find(strcmp(muscleNames,self.meta_arg(j).name));
-                else
-                    idx = ExtFunIO.(self.meta_arg(j).type).(self.meta_arg(j).name);
+                switch self.meta_arg(j).type
+                    case 'muscle'
+                        idx = find(strcmp(muscleNames,self.meta_arg(j).name));
+                    case 'optivar'
+                        switch self.meta_arg(j).subtype
+                            case 'x'
+                                idx = find(strcmp(stateNames,self.meta_arg(j).name));
+                            case 'u'
+                                idx = find(strcmp(controlNames,self.meta_arg(j).name));
+                        end
+                    otherwise
+                        idx = ExtFunIO.(self.meta_arg(j).type).(self.meta_arg(j).name);
                 end
-                arg_fun{j} = arg_SX.(self.meta_arg(j).subtype)(idx,:);
+                    arg_fun{j} = arg_SX.(self.meta_arg(j).subtype)(idx,:);
             end
 
             % evaluate function
@@ -701,10 +859,14 @@ classdef Orthosis < handle
 
             % assign outputs from function to outputs of wrapper function
             for j=1:length(self.meta_res)
-                if strcmp(self.meta_res(j).type,'coordi')
-                    idx = ExtFunIO.(self.meta_res(j).type).(self.meta_res(j).name);
-                else
-                    idx = ExtFunIO.input.(self.meta_res(j).type).(self.meta_res(j).name);
+
+                switch self.meta_res(j).type
+                    case 'coordi'
+                        idx = ExtFunIO.(self.meta_res(j).type).(self.meta_res(j).name);
+                    case 'dyn'
+                        idx = find(strcmp(stateNames,self.meta_res(j).name));
+                    otherwise
+                        idx = ExtFunIO.input.(self.meta_res(j).type).(self.meta_res(j).name);
                 end
                 res_SX.(self.meta_res(j).subtype)(idx,:) = res_fun{j};
             end
@@ -712,13 +874,15 @@ classdef Orthosis < handle
             % collect outputs for post-processing function
             wrap_res_pp = res_fun(length(self.meta_res)+1:end);
 
-            % input arguments for wrapper function
+            % input arguments for wrapper function 
+            % (convert struct to cell array)
             arg_names = fieldnames(arg_SX);
             for i=1:length(arg_names)
                 wrap_arg{i} = arg_SX.(arg_names{i});
             end
 
             % output arguments for wrapper function
+            % (convert struct to cell array)
             res_names = fieldnames(res_SX);
             for i=1:length(res_names)
                 wrap_res{i} = res_SX.(res_names{i});
@@ -827,6 +991,51 @@ classdef Orthosis < handle
                     'input validation'],self.name);
             end
         end % end of inputExistsInOsimModel
+
+        %TODO: Validation function needs to be tested
+        function idx = validateOptivar(self, current_optivar)
+            current_optivar_fullname = ['optivar_' current_optivar];
+            % Ensure current_optivar is a char
+            if ~ischar(current_optivar_fullname)
+                error('validateOptivar:InvalidInput', ...
+                    'current_optivar must be a char, but got type %s.', class(current_optivar_fullname));
+            end
+        
+            % --- Check if it appears in self.names_arg ---
+            matches = strcmp(current_optivar_fullname, self.names_arg);
+        
+            if ~any(matches)
+                error('validateOptivar:NameNotFound', ...
+                    'The variable "%s" does not exist in self.names_arg.', current_optivar_fullname);
+            end
+        
+            if sum(matches) > 1
+                error('validateOptivar:DuplicateName', ...
+                    'The variable "%s" appears multiple times in self.names_arg, but it must be unique.', current_optivar_fullname);
+            end
+        
+            % Get index of match
+            idx = find(matches);
+        
+            % --- Check meta_arg type ---
+            if ~isfield(self.meta_arg, 'type') || ~isfield(self.meta_arg, 'subtype')
+                error('validateOptivar:MissingFields', ...
+                    'self.meta_arg is missing required fields "type" and/or "subtype".');
+            end
+        
+            if ~strcmp(self.meta_arg(idx).type, 'optivar')
+                error('validateOptivar:WrongType', ...
+                    'The entry "%s" exists, but has type "%s" instead of "optivar". These dynamics are defined elsewhere.', ...
+                    current_optivar_fullname, self.meta_arg(idx).type);
+            end
+        
+            if ~strcmp(self.meta_arg(idx).subtype, 'x')
+                error('validateOptivar:WrongSubtype', ...
+                    'The entry "%s" exists with type "optivar", but subtype "%s" instead of "x". Only states (subtype x) can have dynamics defined, not controls (subtype u)', ...
+                    current_optivar_fullname, self.meta_arg(idx).subtype);
+            end
+        end
+
 
     end % end of protected methods
 

--- a/WearableDevices/Orthosis.m
+++ b/WearableDevices/Orthosis.m
@@ -810,22 +810,28 @@ classdef Orthosis < handle
                 self.createCasadiFunction();
             end
 
+            Nstates_all = length(stateNames);
+            Ncontrols_all = length(controlNames);
+
             % all inputs for wrapper function
             arg_SX.q = SX.sym('q',ExtFunIO.jointi.nq.all,self.Nmesh);
             arg_SX.qdot = SX.sym('qdot',ExtFunIO.jointi.nq.all,self.Nmesh);
             arg_SX.qddot = SX.sym('qddot',ExtFunIO.jointi.nq.all,self.Nmesh);
             arg_SX.act = SX.sym('a',length(muscleNames),self.Nmesh);
             arg_SX.fromExtFun = SX.sym('fromExtFun',ExtFunIO.nOutputs,self.Nmesh); % GRFs, point kinematics
-
-            arg_SX.x = SX.sym('optivar_x',length(stateNames), self.Nmesh); % orthosis internal state
-            arg_SX.u = SX.sym('optivar_u',length(controlNames), self.Nmesh); % orthosis controls (to be optimized)
-
+            if self.Nstates > 0
+                arg_SX.x = SX.sym('optivar_x',Nstates_all, self.Nmesh); % orthosis internal state
+            end
+            if self.Ncontrols > 0
+                arg_SX.u = SX.sym('optivar_u',Ncontrols_all, self.Nmesh); % orthosis controls (to be optimized)
+            end
+            
             % all outputs for wrapper function
             res_SX.Mcoord = SX(ExtFunIO.jointi.nq.all,self.Nmesh);
             res_SX.toExtFun = SX(ExtFunIO.input.nInputs,self.Nmesh); % bodyforces, bodymoments
-
-            res_SX.stateDyn = SX(length(stateNames), self.Nmesh); % orthosis internal state dynamics
-
+            if self.Nstates > 0
+                res_SX.stateDyn = SX(Nstates_all, self.Nmesh); % orthosis internal state dynamics
+            end
             % create inputs for function from inputs of wrapper function
             arg_fun = cell(1,self.fun.n_in);
             res_fun = cell(1,self.fun.n_out);

--- a/WearableDevices/hipexo.m
+++ b/WearableDevices/hipexo.m
@@ -49,17 +49,28 @@ side = settings_orthosis.left_right; % 'l' for left or 'r' for right
 
 %u_hipfl_emg = -(emg-0.05)*gain; % only use activation above lower bound (0.05)
 
+%test time variable control
+% timebase = 0:init.Nmesh;
+% if strcmp(side,'l')
+%     TimeVarControl = 10*sin(2*pi*timebase/timebase(end)); %10Nm torque in the middle of cycle
+% else
+%     TimeVarControl = 10*sin(2*pi*timebase/timebase(end)+pi); %10Nm torque in the middle of cycle
+% end
+
 % Simple first order dynamics dx/dt = (u-x)/tau
-tc_tau = 0.1; % time constant in seconds
+tc_tau = 0.05; % time constant in seconds
 state_x = exo.var_opti(['state_x_' side '_side'],'state',[settings_orthosis.dynamics.xl settings_orthosis.dynamics.xu]);
+state_x2 = exo.var_opti(['state_x2_' side '_side'],'state',[settings_orthosis.dynamics.xl settings_orthosis.dynamics.xu]);
 control_u = exo.var_opti(['control_u_' side '_side'],'control',[settings_orthosis.dynamics.ul settings_orthosis.dynamics.uu]);
 
 %control_exo = u_hipfl_emg + control_u; % to make it interesting
 control_exo = control_u;
 
-exo.addDynamics((control_exo-state_x)/tc_tau,['state_x_' side '_side']); %state and control
+%exo.addDynamics((control_exo-state_x)/tc_tau,['state_x_' side '_side']); %state and control
+exo.addDynamics([(control_exo-state_x)/tc_tau;(control_exo-state_x2)/tc_tau],{['state_x_' side '_side'],['state_x2_' side '_side']}); %state and control
 %exo.addDynamics((emg-state_x)/tc_tau,['state_x_' side '_side']); %state, but no control
 exo.addCoordForce(state_x,['hip_flexion_',side]);
+%exo.addCoordForce(state_x+TimeVarControl,['hip_flexion_',side]);
 %exo.addCoordForce(control_u,['hip_flexion_',side]); % add control straight away
 
 %exo.addVarToPostProcessing(state_x,['state_x_' side '_side'])

--- a/WearableDevices/hipexo.m
+++ b/WearableDevices/hipexo.m
@@ -1,0 +1,66 @@
+function [exo] = hipexo(init, settings_orthosis)
+% --------------------------------------------------------------------------
+% Provisional hip exo with 2 hip flexion/extension actuators
+% Example use of adding internal dynamics to the orthosis 
+% using addDynamics method, and adding controls to optimize for (var_opti
+% method)
+%
+% INPUT:
+%   - init -
+%   * struct with information used to initialise the Orthosis object.
+% 
+%   - settings_orthosis -
+%   * struct with information about this orthosis, containing the fields:
+%       - function_name = hipexo  i.e. name of this function   
+%       - gain: EMG gain
+%       - left_right: char, 'l' or 'r'
+%       - dynamics: struct with lower and upper limits for opti controls and
+%           states
+%   Values are set via S.orthosis.settings{i} in main.m, with i the index
+%   of the orthosis.
+%
+%
+% OUTPUT:
+%   - exo -
+%   * an object of the class Orthosis
+% 
+% Original author: Sander De Groof
+% Original date: 3/October/2025
+% --------------------------------------------------------------------------
+
+% create Orthosis object
+exo = Orthosis('exo',init,true);
+
+% read settings that were passed from main.m
+if isfield(settings_orthosis,'isFullGaitCycle')
+    isFullGaitCycle = settings_orthosis.isFullGaitCycle;
+else
+    isFullGaitCycle = false;
+end
+
+side = settings_orthosis.left_right; % 'l' for left or 'r' for right
+gain = settings_orthosis.gain;
+
+emg1 = exo.var_muscle(['glut_max1_',side]);
+emg2 = exo.var_muscle(['glut_max2_',side]);
+emg3 = exo.var_muscle(['glut_max3_',side]);
+
+emg = (emg1 + emg2 + emg3)/3;
+
+u_hipfl_emg = -(emg-0.05)*gain; % only use activation above lower bound (0.05)
+
+% Simple first order dynamics dx/dt = (u-x)/tau
+tc_tau = 0.1; % time constant in seconds
+state_x = exo.var_opti(['state_x_' side '_side'],'state',[settings_orthosis.dynamics.xl settings_orthosis.dynamics.xu]);
+control_u = exo.var_opti(['control_u_' side '_side'],'control',[settings_orthosis.dynamics.ul settings_orthosis.dynamics.uu]);
+
+%control_exo = u_hipfl_emg + control_u; % to make it interesting
+control_exo = control_u;
+
+exo.addDynamics((control_exo-state_x)/tc_tau,['state_x_' side '_side']);
+exo.addCoordForce(state_x,['hip_flexion_',side]);
+
+exo.addVarToPostProcessing(state_x,['state_x_' side '_side'])
+exo.addVarToPostProcessing(control_exo,['control_u_' side '_side'])
+end
+

--- a/WearableDevices/hipexo.m
+++ b/WearableDevices/hipexo.m
@@ -29,7 +29,7 @@ function [exo] = hipexo(init, settings_orthosis)
 % --------------------------------------------------------------------------
 
 % create Orthosis object
-exo = Orthosis('exo',init,true);
+exo = Orthosis('exo',init, true);
 
 % read settings that were passed from main.m
 if isfield(settings_orthosis,'isFullGaitCycle')
@@ -39,15 +39,15 @@ else
 end
 
 side = settings_orthosis.left_right; % 'l' for left or 'r' for right
-gain = settings_orthosis.gain;
+% gain = settings_orthosis.gain;
+% 
+% emg1 = exo.var_muscle(['glut_max1_',side]);
+% emg2 = exo.var_muscle(['glut_max2_',side]);
+% emg3 = exo.var_muscle(['glut_max3_',side]);
+% 
+% emg = (emg1 + emg2 + emg3)/3;
 
-emg1 = exo.var_muscle(['glut_max1_',side]);
-emg2 = exo.var_muscle(['glut_max2_',side]);
-emg3 = exo.var_muscle(['glut_max3_',side]);
-
-emg = (emg1 + emg2 + emg3)/3;
-
-u_hipfl_emg = -(emg-0.05)*gain; % only use activation above lower bound (0.05)
+%u_hipfl_emg = -(emg-0.05)*gain; % only use activation above lower bound (0.05)
 
 % Simple first order dynamics dx/dt = (u-x)/tau
 tc_tau = 0.1; % time constant in seconds
@@ -57,10 +57,13 @@ control_u = exo.var_opti(['control_u_' side '_side'],'control',[settings_orthosi
 %control_exo = u_hipfl_emg + control_u; % to make it interesting
 control_exo = control_u;
 
-exo.addDynamics((control_exo-state_x)/tc_tau,['state_x_' side '_side']);
+exo.addDynamics((control_exo-state_x)/tc_tau,['state_x_' side '_side']); %state and control
+%exo.addDynamics((emg-state_x)/tc_tau,['state_x_' side '_side']); %state, but no control
 exo.addCoordForce(state_x,['hip_flexion_',side]);
+%exo.addCoordForce(control_u,['hip_flexion_',side]); % add control straight away
 
-exo.addVarToPostProcessing(state_x,['state_x_' side '_side'])
-exo.addVarToPostProcessing(control_exo,['control_u_' side '_side'])
+%exo.addVarToPostProcessing(state_x,['state_x_' side '_side'])
+%exo.addVarToPostProcessing(control_exo,['control_u_' side '_side'])
+%exo.addVarToPostProcessing(control_u,['control_u_' side '_side'])
 end
 

--- a/main.m
+++ b/main.m
@@ -36,13 +36,16 @@ addpath(fullfile(pathRepo,'DefaultSettings'))
 
 [S] = initializeSettings('Falisse_et_al_2022');
 
-%% Settings
+%% Settings (custom, defaults are defined in getDefaultSettings.m)
 
 % name of the subject
 S.subject.name = 'Falisse_et_al_2022';
 
 % path to folder where you want to store the results of the OCP
 S.misc.save_folder  = fullfile(pathRepoFolder,'PredSimResults',S.subject.name); 
+
+%full gait cycle
+S.misc.gaitmotion_type = 'FullGaitCycle';
 
 % either choose "quasi-random" or give the path to a .mot file you want to use as initial guess
 S.solver.IG_selection = fullfile(S.misc.main_path,'OCP','IK_Guess_Full_GC.mot');
@@ -52,6 +55,29 @@ S.solver.IG_selection_gaitCyclePercent = 100;
 % give the path to the osim model of your subject
 osim_path = fullfile(pathRepo,'Subjects',S.subject.name,[S.subject.name '.osim']);
 
+% Mesh settings
+S.solver.N_meshes = 10;
+
+%% Add exoskeleton
+
+% select orthosis function
+exo1.function_name = 'hipexo';
+
+% set parameters
+exo1.dynamics.xl = -12; % [Nm]
+exo1.dynamics.xu = 12; % [Nm]
+exo1.dynamics.ul = -10; % [Nm]
+exo1.dynamics.uu = 10; % [Nm]
+
+exo1.gain = 1; %EMG gain for gluteus maximus
+
+% add orthosis on left side
+exo1.left_right = 'l';
+S.orthosis.settings{1} = exo1;
+
+% add the same orthosis on right side
+exo1.left_right = 'r';
+S.orthosis.settings{2} = exo1;
 
 %% Run predictive simulations
 

--- a/main.m
+++ b/main.m
@@ -57,7 +57,7 @@ S.solver.IG_selection_gaitCyclePercent = 100;
 osim_path = fullfile(pathRepo,'Subjects',S.subject.name,[S.subject.name '.osim']);
 
 % Mesh settings
-S.solver.N_meshes = 10;
+S.solver.N_meshes = 5;
 
 %% Add exoskeleton
 

--- a/main.m
+++ b/main.m
@@ -44,8 +44,9 @@ S.subject.name = 'Falisse_et_al_2022';
 % path to folder where you want to store the results of the OCP
 S.misc.save_folder  = fullfile(pathRepoFolder,'PredSimResults',S.subject.name); 
 
-%full gait cycle
+% gait cycle
 S.misc.gaitmotion_type = 'FullGaitCycle';
+%S.misc.gaitmotion_type = 'HalfGaitCycle';
 
 % either choose "quasi-random" or give the path to a .mot file you want to use as initial guess
 S.solver.IG_selection = fullfile(S.misc.main_path,'OCP','IK_Guess_Full_GC.mot');
@@ -64,10 +65,10 @@ S.solver.N_meshes = 10;
 exo1.function_name = 'hipexo';
 
 % set parameters
-exo1.dynamics.xl = -12; % [Nm]
-exo1.dynamics.xu = 12; % [Nm]
-exo1.dynamics.ul = -10; % [Nm]
-exo1.dynamics.uu = 10; % [Nm]
+exo1.dynamics.xl = -17; % [Nm]
+exo1.dynamics.xu = 17; % [Nm]
+exo1.dynamics.ul = -15; % [Nm]
+exo1.dynamics.uu = 15; % [Nm]
 
 exo1.gain = 1; %EMG gain for gluteus maximus
 

--- a/main.m
+++ b/main.m
@@ -57,7 +57,7 @@ S.solver.IG_selection_gaitCyclePercent = 100;
 osim_path = fullfile(pathRepo,'Subjects',S.subject.name,[S.subject.name '.osim']);
 
 % Mesh settings
-S.solver.N_meshes = 5;
+S.solver.N_meshes = 20;
 
 %% Add exoskeleton
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Provide a short overview of the changes -->
Orthosis control or states can be defined with `Orthosis.var_opti() `method. 
The user must provide bounds and scaledbounds (usually -1 to 1) for each var_opti
For states, custom dynamics must be added with `Orthosis.addDynamics()` method
These states and controls will be optimized for, without changing the cost function.
A plotting function for orthosis states, controls and coordinate torques was also added.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Exoskeleton actuators can have important dynamics (actuator mechanics, controllers and filters), that some users may want to model. If users wants to find optimal control for their exo to help lower the cost function, this is now possible.
This involved some major additions to OCP_formulation.m, with different handling for time(in)variable orthoses, and wheter or not the orthosis has states or controls.

## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
`test_PredSim.m` (test 1): Outcome successfull

Added 2 hip exos (hipexo.m) in 5 configurations
1.  no var_opti() states or controls (isTimeVariable = true)
2. 1 state (with simple 1st order dynamics), no controls  (isTimeVariable = true)
3. 1 control, no states  (isTimeVariable = true)
4. 1 state and 1 control  (isTimeVariable = true)
5. 1 state and 1 control (isTimeVariable = false)
Outcome: Plausible results, 1st order dynamics seem to be respected

## Suggested tests for reviewers
<!---Please describe tests for the reviewer to run -->
Timevariable control (such as with `ankleExoZhang2017.m`) that also involves a state and oprionally also a control, still needs to be tested.
The handling on HalfGaitCycle type simulations has not been thoroughly coded or tested

<!--- Assign labels ("Labels" tab in side bar). Each PR should have at least one "Review:..." label, since we use these to allocate reviewers. -->
<!--- Do not add requested reviewers, unless this person specifically agreed to review your PR. -->
<!--- If you are a collaborator (i.e. have direct write access to this repo) select yourself as assignee, otherwise someone will be assigned to your PR. -->
