### PR TITLE
Add instructions on how the linear solvers from HSL can be obtained

### DIFF
--- a/Documentation/GetLinearSolversHSL.md
+++ b/Documentation/GetLinearSolversHSL.md
@@ -1,0 +1,47 @@
+
+Get a library with HSL linear solvers for use with ipopt
+========================================================
+
+Before getting the source code make sure to read the terms of the licence, especially regarding sharing of the software.
+
+1. Get the source code for the HSL solvers from https://licences.stfc.ac.uk/product/coin-hsl. 
+You will receive `coinhsl-2021.05.05.zip` (or maybe a newer version?).
+
+2. Install [MSYS2](https://www.msys2.org/)
+
+3. Run MinGW64 (came with MSYS2), this will open a command window.
+    > Use right-click or shift+insert to paste text into this window, ctrl+v does not work.
+    > Make sure all file paths use `/`, not `\`.
+
+4. Install packages
+- In the MinGW64 command window, run:
+    - General utility `pacman -S git make pkg-config`
+    - GNU compilers (c and fortran) `pacman -S mingw-w64-x86_64-gcc mingw-w64-x86_64-gcc-fortran`
+    - Dependencies for solvers (lapack for math, metis for matrix ordering) `pacman -S mingw-w64-x86_64-lapack mingw-w64-x86_64-metis`
+
+5. Organise the source code
+- In the MinGW64 command window, run:
+    - Go to a base folder `cd c:/documents/coin-or/coinhsl`
+    - `mkdir source`
+    - `cd source`
+    - `git clone https://github.com/coin-or-tools/ThirdParty-HSL.git`
+- In file explorer:
+    - extract `coinhsl-2021.05.05.zip` into `c:/documents/coin-or/coinhsl/source/ThirdParty-HSL`
+    - rename `coinhsl-2021.05.05` to `coinhsl`
+
+6. Compile the code
+- In the MinGW64 command window, run:
+    - Go to the folder with source code `cd c:/documents/coin-or/coinhsl/source/ThirdParty-HSL`
+    - Configure the compiler `./configure --prefix="/c/documents/coin-or/coinhsl/build"--enable-openmp`
+    - `make`
+    - `make install`
+- In `c:/documents/coin-or/coinhsl/build/bin/`, rename `libcoinhsl-2.dll` to `libhsl.dll`. 
+
+7. Use the new solver
+- In `/PredSim/main.m`, add:
+```
+S.solver.ipopt_options.hsllib = 'c:/documents/coin-or/coinhsl/build/bin/libhsl.dll';
+S.solver.linear_solver = 'ma97';
+```
+
+

--- a/Documentation/GetLinearSolversHSL.md
+++ b/Documentation/GetLinearSolversHSL.md
@@ -6,31 +6,31 @@ Before getting the source code make sure to read the terms of the licence, espec
 
 1.	Download the solver
 
-> Go to : https://licences.stfc.ac.uk/product/coin-hsl
+- Go to : https://licences.stfc.ac.uk/product/coin-hsl
 
-> Click on HSL Academic Licence -> ORDER NOW
+- Click on HSL Academic Licence -> ORDER NOW
 
-> Create an account or Sign in if you already have an account.
+- Create an account or Sign in if you already have an account.
 
-> You will receive a download link via email 1 or 2 days later.
+- You will receive a download link via email 1 or 2 days later.
 
-> Download CoinHSL 2024.05.15 (windows binaries) via de link received via email:
+- Download CoinHSL 2024.05.15 (windows binaries) via de link received via email:
     
   	<img width="945" height="86" alt="image" src="https://github.com/user-attachments/assets/25c327ab-95e6-4a23-873f-8ea33b16d4f2" />
  
-3.	Add the path of the solver to the system path of your computer
+2.	Add the path of the solver to the system path of your computer
 
 Once you unzipped the folder on your computer, you will see a subfolder named “bin”. It is important that you add this to the system path of your pc. If you don’t than windows will not know where the solver is and then you will run into problems.
 
-> Search in windows for “Edit the system environment variables” 
+- Search in windows for “Edit the system environment variables” 
 
-> Click on “Path” in “System variables” and then “Edit” or Double click on “Path”
+- Click on “Path” in “System variables” and then “Edit” or Double click on “Path”
 
-> Add the path to you’re the subfolder “bin” in the list like this: C:\...\CoinHSL.v2024.5.15.x86_64-w64-mingw32-libgfortran5\bin (de path is depending on where you unzipped the              downloaded folder)
+- Add the path to you’re the subfolder “bin” in the list like this: C:\...\CoinHSL.v2024.5.15.x86_64-w64-mingw32-libgfortran5\bin (de path is depending on where you unzipped the              downloaded folder)
 
   	<img width="945" height="101" alt="image" src="https://github.com/user-attachments/assets/ffae9b3e-58a3-49ba-80af-f538d5ba3fbb" />
 
-5.	Use the new solver.
+3.	Use the new solver.
 
 In PredSim/main.m, add:
 

--- a/Documentation/GetLinearSolversHSL.md
+++ b/Documentation/GetLinearSolversHSL.md
@@ -4,42 +4,27 @@ Get a library with HSL linear solvers for use with ipopt
 
 Before getting the source code make sure to read the terms of the licence, especially regarding sharing of the software.
 
-1. Get the source code for the HSL solvers from https://licences.stfc.ac.uk/product/coin-hsl. 
-You will receive `coinhsl-2021.05.05.zip` (or maybe a newer version?).
+1.	Download the solver.
+    •	Go to : https://licences.stfc.ac.uk/product/coin-hsl
+    •	Click on HSL Academic Licence -> ORDER NOW
+    •	Create an account or Sign in if you already have an account. 
+    •	You will receive a download link via email 1 or 2 days later. 
+    •	Download CoinHSL 2024.05.15 (windows binaries) via de link received via email:
+  	<img width="945" height="86" alt="image" src="https://github.com/user-attachments/assets/25c327ab-95e6-4a23-873f-8ea33b16d4f2" />
+ 
+2.	Add the path of the solver to the system path of your computer
+    •	Once you unzipped the folder on your computer, you will see a subfolder named “bin”. It is important that you add this to the system path of your pc. If you don’t than windows will         not know where the solver is and then you will run into problems. 
+        o	Search in windows for “Edit the system environment variables” 
+        o	Click on “Path” in “System variables” and then “Edit” or Double click on “Path”
+        o	Add the path to you’re the subfolder “bin” in the list like this: C:\...\CoinHSL.v2024.5.15.x86_64-w64-mingw32-libgfortran5\bin (de path is depending on where you unzipped the              downloaded folder)
+  	<img width="945" height="101" alt="image" src="https://github.com/user-attachments/assets/ffae9b3e-58a3-49ba-80af-f538d5ba3fbb" />
 
-2. Install [MSYS2](https://www.msys2.org/)
+3.	Use the new solver. 
+    •	In PredSim/main.m, add: 
+    S.solver.ipopt_options.hsllib = 'C:/…./bin/libhsl.dll'; (depending on where you unzipped the solver)
+    S.solver.linear_solver = 'ma97';
+    •	Imporant! Use the most recent version of CASADI.  
 
-3. Run MinGW64 (came with MSYS2), this will open a command window.
-    > Use right-click or shift+insert to paste text into this window, ctrl+v does not work.
-    > Make sure all file paths use `/`, not `\`.
-
-4. Install packages
-- In the MinGW64 command window, run:
-    - General utility `pacman -S git make pkg-config`
-    - GNU compilers (c and fortran) `pacman -S mingw-w64-x86_64-gcc mingw-w64-x86_64-gcc-fortran`
-    - Dependencies for solvers (lapack for math, metis for matrix ordering) `pacman -S mingw-w64-x86_64-lapack mingw-w64-x86_64-metis`
-
-5. Organise the source code
-- In the MinGW64 command window, run:
-    - Go to a base folder `cd c:/documents/coin-or/coinhsl`
-    - `mkdir source`
-    - `cd source`
-    - `git clone https://github.com/coin-or-tools/ThirdParty-HSL.git`
-- In file explorer:
-    - extract `coinhsl-2021.05.05.zip` into `c:/documents/coin-or/coinhsl/source/ThirdParty-HSL`
-    - rename `coinhsl-2021.05.05` to `coinhsl`
-
-6. Compile the code
-- In the MinGW64 command window, run:
-    - Go to the folder with source code `cd c:/documents/coin-or/coinhsl/source/ThirdParty-HSL`
-    - Configure the compiler `./configure --prefix="/c/documents/coin-or/coinhsl/build"--enable-openmp`
-    - `make`
-    - `make install`
-- In `c:/documents/coin-or/coinhsl/build/bin/`, rename `libcoinhsl-2.dll` to `libhsl.dll`. 
-
-7. Use the new solver
-- In `/PredSim/main.m`, add:
-```
 S.solver.ipopt_options.hsllib = 'c:/documents/coin-or/coinhsl/build/bin/libhsl.dll';
 S.solver.linear_solver = 'ma97';
 ```

--- a/Documentation/GetLinearSolversHSL.md
+++ b/Documentation/GetLinearSolversHSL.md
@@ -5,22 +5,33 @@ Get a library with HSL linear solvers for use with ipopt
 Before getting the source code make sure to read the terms of the licence, especially regarding sharing of the software.
 
 1.	Download the solver
+
 Go to : https://licences.stfc.ac.uk/product/coin-hsl
+
 Click on HSL Academic Licence -> ORDER NOW
+
 Create an account or Sign in if you already have an account.
+
 You will receive a download link via email 1 or 2 days later.
+
 Download CoinHSL 2024.05.15 (windows binaries) via de link received via email:
     
   	<img width="945" height="86" alt="image" src="https://github.com/user-attachments/assets/25c327ab-95e6-4a23-873f-8ea33b16d4f2" />
  
 3.	Add the path of the solver to the system path of your computer
+
 Once you unzipped the folder on your computer, you will see a subfolder named “bin”. It is important that you add this to the system path of your pc. If you don’t than windows will not know where the solver is and then you will run into problems.
+
 Search in windows for “Edit the system environment variables” 
+
 Click on “Path” in “System variables” and then “Edit” or Double click on “Path”
+
 Add the path to you’re the subfolder “bin” in the list like this: C:\...\CoinHSL.v2024.5.15.x86_64-w64-mingw32-libgfortran5\bin (de path is depending on where you unzipped the              downloaded folder)
+
   	<img width="945" height="101" alt="image" src="https://github.com/user-attachments/assets/ffae9b3e-58a3-49ba-80af-f538d5ba3fbb" />
 
 5.	Use the new solver.
+
 In PredSim/main.m, add:
 
 ```

--- a/Documentation/GetLinearSolversHSL.md
+++ b/Documentation/GetLinearSolversHSL.md
@@ -6,15 +6,15 @@ Before getting the source code make sure to read the terms of the licence, espec
 
 1.	Download the solver
 
-Go to : https://licences.stfc.ac.uk/product/coin-hsl
+> Go to : https://licences.stfc.ac.uk/product/coin-hsl
 
-Click on HSL Academic Licence -> ORDER NOW
+> Click on HSL Academic Licence -> ORDER NOW
 
-Create an account or Sign in if you already have an account.
+> Create an account or Sign in if you already have an account.
 
-You will receive a download link via email 1 or 2 days later.
+> You will receive a download link via email 1 or 2 days later.
 
-Download CoinHSL 2024.05.15 (windows binaries) via de link received via email:
+> Download CoinHSL 2024.05.15 (windows binaries) via de link received via email:
     
   	<img width="945" height="86" alt="image" src="https://github.com/user-attachments/assets/25c327ab-95e6-4a23-873f-8ea33b16d4f2" />
  
@@ -22,11 +22,11 @@ Download CoinHSL 2024.05.15 (windows binaries) via de link received via email:
 
 Once you unzipped the folder on your computer, you will see a subfolder named “bin”. It is important that you add this to the system path of your pc. If you don’t than windows will not know where the solver is and then you will run into problems.
 
-Search in windows for “Edit the system environment variables” 
+> Search in windows for “Edit the system environment variables” 
 
-Click on “Path” in “System variables” and then “Edit” or Double click on “Path”
+> Click on “Path” in “System variables” and then “Edit” or Double click on “Path”
 
-Add the path to you’re the subfolder “bin” in the list like this: C:\...\CoinHSL.v2024.5.15.x86_64-w64-mingw32-libgfortran5\bin (de path is depending on where you unzipped the              downloaded folder)
+> Add the path to you’re the subfolder “bin” in the list like this: C:\...\CoinHSL.v2024.5.15.x86_64-w64-mingw32-libgfortran5\bin (de path is depending on where you unzipped the              downloaded folder)
 
   	<img width="945" height="101" alt="image" src="https://github.com/user-attachments/assets/ffae9b3e-58a3-49ba-80af-f538d5ba3fbb" />
 

--- a/Documentation/GetLinearSolversHSL.md
+++ b/Documentation/GetLinearSolversHSL.md
@@ -4,29 +4,31 @@ Get a library with HSL linear solvers for use with ipopt
 
 Before getting the source code make sure to read the terms of the licence, especially regarding sharing of the software.
 
-1.	Download the solver.
-    •	Go to : https://licences.stfc.ac.uk/product/coin-hsl
-    •	Click on HSL Academic Licence -> ORDER NOW
-    •	Create an account or Sign in if you already have an account. 
-    •	You will receive a download link via email 1 or 2 days later. 
-    •	Download CoinHSL 2024.05.15 (windows binaries) via de link received via email:
+1.	Download the solver
+Go to : https://licences.stfc.ac.uk/product/coin-hsl
+Click on HSL Academic Licence -> ORDER NOW
+Create an account or Sign in if you already have an account.
+You will receive a download link via email 1 or 2 days later.
+Download CoinHSL 2024.05.15 (windows binaries) via de link received via email:
+    
   	<img width="945" height="86" alt="image" src="https://github.com/user-attachments/assets/25c327ab-95e6-4a23-873f-8ea33b16d4f2" />
  
-2.	Add the path of the solver to the system path of your computer
-    •	Once you unzipped the folder on your computer, you will see a subfolder named “bin”. It is important that you add this to the system path of your pc. If you don’t than windows will         not know where the solver is and then you will run into problems. 
-        o	Search in windows for “Edit the system environment variables” 
-        o	Click on “Path” in “System variables” and then “Edit” or Double click on “Path”
-        o	Add the path to you’re the subfolder “bin” in the list like this: C:\...\CoinHSL.v2024.5.15.x86_64-w64-mingw32-libgfortran5\bin (de path is depending on where you unzipped the              downloaded folder)
+3.	Add the path of the solver to the system path of your computer
+Once you unzipped the folder on your computer, you will see a subfolder named “bin”. It is important that you add this to the system path of your pc. If you don’t than windows will not know where the solver is and then you will run into problems.
+Search in windows for “Edit the system environment variables” 
+Click on “Path” in “System variables” and then “Edit” or Double click on “Path”
+Add the path to you’re the subfolder “bin” in the list like this: C:\...\CoinHSL.v2024.5.15.x86_64-w64-mingw32-libgfortran5\bin (de path is depending on where you unzipped the              downloaded folder)
   	<img width="945" height="101" alt="image" src="https://github.com/user-attachments/assets/ffae9b3e-58a3-49ba-80af-f538d5ba3fbb" />
 
-3.	Use the new solver. 
-    •	In PredSim/main.m, add: 
+5.	Use the new solver.
+In PredSim/main.m, add:
+
+```
     S.solver.ipopt_options.hsllib = 'C:/…./bin/libhsl.dll'; (depending on where you unzipped the solver)
     S.solver.linear_solver = 'ma97';
-    •	Imporant! Use the most recent version of CASADI.  
-
-S.solver.ipopt_options.hsllib = 'c:/documents/coin-or/coinhsl/build/bin/libhsl.dll';
-S.solver.linear_solver = 'ma97';
 ```
+
+Imporant! Use the most recent version of CASADI.  
+
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Provide a short overview of the changes -->
Added instructions on how to obtain the source code for the HSL linear solvers and compile them into a library that can be used with ipopt.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
These solvers are better than the ones included in casadi. Their licence prohibits distributing them, so users have to get the solvers by themselves.

In a reference simulation with model Falisse_et_al_2022, using linear solver *ma97* instead of *mumps* (default), reduced simulation time by 24 minutes.

## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
<!--- Please describe the outcome of these tests. -->
Ran testing simulations with additional settings in main.m
```
S.solver.ipopt_options.hsllib = 'c:/documents/coin-or/coinhsl/build/bin/libhsl.dll';
S.solver.linear_solver = 'ma97';
```

## Suggested tests for reviewers
<!---Please describe tests for the reviewer to run -->
Run a simulation with additional settings in main.m
```
S.solver.ipopt_options.hsllib = 'c:/documents/coin-or/coinhsl/build/bin/libhsl.dll';
S.solver.linear_solver = 'ma97';
```

<!--- Assign labels ("Labels" tab in side bar). Each PR should have at least one "Review:..." label, since we use these to allocate reviewers. -->
<!--- Do not add requested reviewers, unless this person specifically agreed to review your PR. -->
<!--- If you are a collaborator (i.e. have direct write access to this repo) select yourself as assignee, otherwise someone will be assigned to your PR. -->
