### PR TITLE
No OpenSim logfile

### DIFF
--- a/runPredSim.m
+++ b/runPredSim.m
@@ -34,6 +34,8 @@ elseif ~isempty(S.solver.CasADi_path) && ~isfolder(S.solver.CasADi_path)
         " \n\t%s",S.solver.CasADi_path)
 end
 
+% Disable OpenSim log files
+org.opensim.modeling.Logger.setLevelString("off");
 
 if S.solver.run_as_batch_job
     % add to batch


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Provide a short overview of the changes -->
When interacting with OpenSim from matlab, OpenSim writes information to a logfile. We do not need this information, so tell OpenSim to not write the log.
Alternative to solution in PR #239.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- When running multiple instances of PredSim at the same time (e.g. on a cluster), they all try to write the same logfile which can cause problems.
- In general, avoid creating files that are not needed.

## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
<!--- Please describe the outcome of these tests. -->
Ran test simulation (10 iterations).

## Suggested tests for reviewers
<!---Please describe tests for the reviewer to run -->
Steps:
1. remove _opensim.log_ from the subject folder
2. run `main.m` (you can set `S.solver.max_iter = 10;`)
3. observe how _opensim.log_ was not created in the subject folder

<!--- Assign labels ("Labels" tab in side bar). Each PR should have at least one "Review:..." label, since we use these to allocate reviewers. -->
<!--- Do not add requested reviewers, unless this person specifically agreed to review your PR. -->
<!--- If you are a collaborator (i.e. have direct write access to this repo) select yourself as assignee, otherwise someone will be assigned to your PR. -->
