### PR TITLE
prevents error vsc simulations

### DIFF
--- a/VariousFunctions/mvpolyfit.m
+++ b/VariousFunctions/mvpolyfit.m
@@ -146,7 +146,8 @@ for fit_order=min(order):max(order)
     
     % Fit coeff
     coeff = mldivide_impl(X_aug, Y_aug);
-    
+    coeff = coeff(1:size(X_aug, 2));
+      
     % Evaluate acceptance criteria
     Y_fit = mno*coeff;
     rmse_y = rms(Y - Y_fit);
@@ -231,7 +232,7 @@ if options.reduced_coeff
         % Coefficient values that best fit data using only the subset of 
         % selected coefficients
         coeff_aux = mldivide_impl(X_aug(:, selected_index), Y_aug);
-            
+        coeff_aux = coeff_aux(1:size(X_aug(:, selected_index),2));
 
         % Update the full coefficient vector with the selected ones
         coeff_2 = zeros(size(mno, 2), 1);


### PR DESCRIPTION
Prevent error VSC simulations by adjust matrix size of coeff variable

## Description
VSC simulations were giving an error, see this issue: https://github.com/KULeuvenNeuromechanics/PredSim/issues/256. This was due to an incorrect size of `coeff` variable created from the `mldivide_lapack` function. This bug only occurred on the vsc because that's the only place where `mldivide_lapack` is used. In the version before Nov 14 2025, the size of the `coeff` variable was adjusted, but this change got lost in this merge: https://github.com/KULeuvenNeuromechanics/PredSim/pull/233. It remains to be investigated why the size of the output of `mldivide_lapack` needs to be corrected (not needed for regular mldivide). 

## How Has This Been Tested?
Running a simulation on the cluster using default main.m settings (i.e. Falisse model). This did not trigger any errors. 

## Suggested tests for reviewers
- Run regular simulation and compare output to reference simulation
- Run simulation on the cluster, check whether it runs without errors
- Compare cluster simulation with a reference simulation
- Test the adjusted function (see: https://github.com/KULeuvenNeuromechanics/PredSim/blob/master/Tests/test_mvpolyfit.m). 
You could change the function at the top, so it's a polynomial. Then the fit should give the same function.