### PR TITLE
change to wice cluster as default

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,8 +100,8 @@ the cluster.
 ```bash
 #!/bin/bash -l
 
-#SBATCH --cluster=genius
-#SBATCH --partition=batch
+#SBATCH --cluster=wice
+#SBATCH --partition=batch_icelake
 #SBATCH --ntasks-per-node=1
 #SBATCH --nodes=1
 #SBATCH --account=<credit_account>

--- a/run_simulation.slurm
+++ b/run_simulation.slurm
@@ -1,7 +1,7 @@
 #!/bin/bash -l
 
-#SBATCH --cluster=genius
-#SBATCH --partition=batch
+#SBATCH --cluster=wice
+#SBATCH --partition=batch_icelake
 #SBATCH --ntasks-per-node=1
 #SBATCH --nodes=1
 #SBATCH --account=<credit_account>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Provide a short overview of the changes -->
Since [Genius reaches end of life](https://docs.vscentrum.be/leuven/tier2_hardware/genius_hardware.html), the default cluster is changed to [wICE (batch_icelake)](https://docs.vscentrum.be/leuven/tier2_hardware/wice_hardware.html).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Genius EOL.

## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
<!--- Please describe the outcome of these tests. -->
Run simulation with with these new SBATCH settings.

## Suggested tests for reviewers
<!---Please describe tests for the reviewer to run -->
Run simulation with with these new SBATCH settings.

<!--- Assign labels ("Labels" tab in side bar). Each PR should have at least one "Review:..." label, since we use these to allocate reviewers. -->
<!--- Do not add requested reviewers, unless this person specifically agreed to review your PR. -->
<!--- If you are a collaborator (i.e. have direct write access to this repo) select yourself as assignee, otherwise someone will be assigned to your PR. -->
