### PR TITLE
disable automatic workflow runs

### DIFF
--- a/.github/workflows/build_website.yml
+++ b/.github/workflows/build_website.yml
@@ -3,7 +3,7 @@ name: Build Sphinx website
 # can be downloaded from the github actions tab to be reviewed locally.
 
 on:
-  pull_request:
+  # pull_request:
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,8 +2,8 @@ name: Deploy Sphinx to GitHub Pages
 # Builds the website and deploys the updates online when the master branch is updated.
 
 on:
-  push:
-    branches: ["master"]
+  # push:
+  #   branches: ["master"]
   #release:
   #  types: [published]
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Provide a short overview of the changes -->
Disabled automatic workflow runs, manually running a workflow is still possible.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- Automatic updating of website is currently not needed.
- I have a suspicion that the workflows affect repo traffic, so I want to test this.

## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
<!--- Please describe the outcome of these tests. -->
n/a

## Suggested tests for reviewers
<!---Please describe tests for the reviewer to run -->
n/a

<!--- Assign labels ("Labels" tab in side bar). Each PR should have at least one "Review:..." label, since we use these to allocate reviewers. -->
<!--- Do not add requested reviewers, unless this person specifically agreed to review your PR. -->
<!--- If you are a collaborator (i.e. have direct write access to this repo) select yourself as assignee, otherwise someone will be assigned to your PR. -->
